### PR TITLE
Fixed wrong data type in dDataTransfer messages

### DIFF
--- a/ocpp/v16/call.py
+++ b/ocpp/v16/call.py
@@ -214,4 +214,4 @@ class StatusNotificationPayload:
 class DataTransferPayload:
     vendor_id: str
     message_id: str = None
-    data: Any = None
+    data: str = None

--- a/ocpp/v16/call_result.py
+++ b/ocpp/v16/call_result.py
@@ -172,4 +172,4 @@ class UpdateFirmwarePayload:
 @dataclass
 class DataTransferPayload:
     status: str
-    data: Dict = None
+    data: str = None


### PR DESCRIPTION
As Rahul Dahiya <rahuldahiya33@gmail.com> mentioned, the data type of DataTransfer was wrong. This PR is to fix that issue.