### PR TITLE
Don't reraise exception in finally block

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -247,16 +247,11 @@ class ChargePoint:
 
         # Use a lock to prevent make sure that only 1 message can be send at a
         # a time.
-        await self._call_lock.acquire()
-
-        try:
+        async with self._call_lock:
             await self._send(call.to_json())
             response = \
                 await self._get_specific_response(call.unique_id,
                                                   self._response_timeout)
-        finally:
-            self._call_lock.release()
-            raise
 
         if response.message_type_id == MessageType.CallError:
             LOGGER.warning("Received a CALLError: %s'", response)


### PR DESCRIPTION
The fix introduced for #46 contained a bug. `ChargePoint.call()`
could fail with:

``` python
	try:
	    await self._send(call.to_json())
	    response = \
		await self._get_specific_response(call.unique_id,
						  self._response_timeout)
	finally:
	    self._call_lock.release()
>           raise
E           RuntimeError: No active exception to reraise
```

Fixes: #50