### PR TITLE
Add arg `skip_schema_validation` to @on()

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -140,11 +140,6 @@ class ChargePoint:
             return
 
         if msg.message_type_id == MessageType.Call:
-            # Call's can be validated right away because the 'action' is known.
-            # The 'action' is required to get the correct schema.
-            #
-            # CallResult's don't have an action field. The action must be
-            # deducted from corresponding Call.
             await self._handle_call(msg)
         elif msg.message_type_id in \
                 [MessageType.CallResult, MessageType.CallError]:

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -140,12 +140,11 @@ class ChargePoint:
             return
 
         if msg.message_type_id == MessageType.Call:
-            # Call's can be validated right away because the 'action' is know.
+            # Call's can be validated right away because the 'action' is known.
             # The 'action' is required to get the correct schema.
             #
             # CallResult's don't have an action field. The action must be
             # deducted from corresponding Call.
-            validate_payload(msg, self._ocpp_version)
             await self._handle_call(msg)
         elif msg.message_type_id in \
                 [MessageType.CallResult, MessageType.CallError]:
@@ -167,6 +166,9 @@ class ChargePoint:
         except KeyError:
             raise NotImplementedError(f"No handler for '{msg.action}' "
                                       "registered.")
+
+        if not handlers.get('_skip_schema_validation', False):
+            validate_payload(msg, self._ocpp_version)
 
         # OCPP uses camelCase for the keys in the payload. It's more pythonic
         # to use snake_case for keyword arguments. Therefore the keys must be
@@ -205,7 +207,9 @@ class ChargePoint:
         camel_case_payload = snake_to_camel_case(response_payload)
 
         response = msg.create_call_result(camel_case_payload)
-        validate_payload(response, self._ocpp_version)
+
+        if not handlers.get('_skip_schema_validation', False):
+            validate_payload(response, self._ocpp_version)
 
         await self._send(response.to_json())
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9,7 +9,7 @@ def test_create_route_map():
 
     """
     class ChargePoint:
-        @on(Action.Heartbeat)
+        @on(Action.Heartbeat, skip_schema_validation=True)
         def on_heartbeat(self):
             pass
 
@@ -31,8 +31,10 @@ def test_create_route_map():
         Action.Heartbeat: {
             '_on_action': cp.on_heartbeat,
             '_after_action': cp.after_heartbeat,
+            '_skip_schema_validation': True,
         },
         Action.MeterValues: {
             '_on_action': cp.meter_values,
+            '_skip_schema_validation': False,
         },
     }


### PR DESCRIPTION
The argument can be used to skip validation of a request and response.
It defaults to `False`, so by default validation is enabled.

The reasoning for this change is that TMH has charge points which use
measurands inside MeterValues messages which are not compliant with the
OCPP 1.6 specification. Therefore the validation of these messages fail.

With this new argument validation of certain messages can be disabled.

Fixes: #54