### PR TITLE
Updating to the new versions OCPP1.6 schemas

### DIFF
--- a/ocpp/v16/schemas/AuthorizeResponse.json
+++ b/ocpp/v16/schemas/AuthorizeResponse.json
@@ -6,16 +6,6 @@
         "idTagInfo": {
             "type": "object",
             "properties": {
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "Accepted",
-                        "Blocked",
-                        "Expired",
-                        "Invalid",
-                        "ConcurrentTx"
-                    ]
-                },
                 "expiryDate": {
                     "type": "string",
                     "format": "date-time"
@@ -23,8 +13,20 @@
                 "parentIdTag": {
                     "type": "string",
                     "maxLength": 20
+                },
+                "status": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Accepted",
+                        "Blocked",
+                        "Expired",
+                        "Invalid",
+                        "ConcurrentTx"
+                    ]
                 }
             },
+            "additionalProperties": false,
             "required": [
                 "status"
             ]

--- a/ocpp/v16/schemas/BootNotificationResponse.json
+++ b/ocpp/v16/schemas/BootNotificationResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Pending",
@@ -16,7 +17,7 @@
             "format": "date-time"
         },
         "interval": {
-            "type": "number"
+            "type": "integer"
         }
     },
     "additionalProperties": false,

--- a/ocpp/v16/schemas/CancelReservationResponse.json
+++ b/ocpp/v16/schemas/CancelReservationResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected"

--- a/ocpp/v16/schemas/ChangeAvailability.json
+++ b/ocpp/v16/schemas/ChangeAvailability.json
@@ -8,6 +8,7 @@
         },
         "type": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Inoperative",
                 "Operative"

--- a/ocpp/v16/schemas/ChangeAvailabilityResponse.json
+++ b/ocpp/v16/schemas/ChangeAvailabilityResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected",

--- a/ocpp/v16/schemas/ChangeConfigurationResponse.json
+++ b/ocpp/v16/schemas/ChangeConfigurationResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected",

--- a/ocpp/v16/schemas/ClearCacheResponse.json
+++ b/ocpp/v16/schemas/ClearCacheResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected"

--- a/ocpp/v16/schemas/ClearChargingProfile.json
+++ b/ocpp/v16/schemas/ClearChargingProfile.json
@@ -11,6 +11,7 @@
         },
         "chargingProfilePurpose": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "ChargePointMaxProfile",
                 "TxDefaultProfile",

--- a/ocpp/v16/schemas/ClearChargingProfileResponse.json
+++ b/ocpp/v16/schemas/ClearChargingProfileResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Unknown"

--- a/ocpp/v16/schemas/DataTransferResponse.json
+++ b/ocpp/v16/schemas/DataTransferResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected",

--- a/ocpp/v16/schemas/DiagnosticsStatusNotification.json
+++ b/ocpp/v16/schemas/DiagnosticsStatusNotification.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Idle",
                 "Uploaded",

--- a/ocpp/v16/schemas/FirmwareStatusNotification.json
+++ b/ocpp/v16/schemas/FirmwareStatusNotification.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Downloaded",
                 "DownloadFailed",

--- a/ocpp/v16/schemas/GetCompositeSchedule.json
+++ b/ocpp/v16/schemas/GetCompositeSchedule.json
@@ -4,22 +4,23 @@
     "type": "object",
     "properties": {
         "connectorId": {
-        	"type": "integer"
+            "type": "integer"
         },
-	"duration": {
-		"type": "integer"
-	},
-	"chargingRateUnit": {
-		"type": "string",
-		"enum": [
-			"A",
-			"W"
-			]
-		}
+    "duration": {
+        "type": "integer"
+    },
+    "chargingRateUnit": {
+        "type": "string",
+        "additionalProperties": false,
+        "enum": [
+            "A",
+            "W"
+            ]
+        }
     },
     "additionalProperties": false,
     "required": [
         "connectorId",
-	    "duration"
+        "duration"
     ]
 }

--- a/ocpp/v16/schemas/GetCompositeScheduleResponse.json
+++ b/ocpp/v16/schemas/GetCompositeScheduleResponse.json
@@ -5,68 +5,72 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected"
             ]
         },
-	"connectorId": {
-		"type": "integer"
+    "connectorId": {
+        "type": "integer"
         },
-	"scheduleStart": {
-		"type": "string",
-		"format": "date-time"
-	},
-	"chargingSchedule": {
-		"type": "object",
-		"properties": {
-			"duration": {
-				"type": "integer"
-			},
-			"startSchedule": {
-				"type": "string",
-				"format": "date-time"
-			},
-			"chargingRateUnit": {
-				"type": "string",
-				"enum": [
-					"A",
-					"W"
-					]
-			},
-			"chargingSchedulePeriod": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"startPeriod": {
-							"type": "integer"
-						},
-						"limit": {
-							"type": "number",
-						    "multipleOf" : 0.1
-						},
-						"numberPhases": {
-							"type": "integer"
-						}
-					},
-					"required": [
-						"startPeriod",
-						"limit"
-						]
-				}
-			},
-			"minChargingRate": {
-				"type": "number",
-				"multipleOf" : 0.1
-			}
-		},
-		"required": [
-			"chargingRateUnit",
-			"chargingSchedulePeriod"
-		]
-		}
-	},
+    "scheduleStart": {
+        "type": "string",
+        "format": "date-time"
+    },
+    "chargingSchedule": {
+        "type": "object",
+        "properties": {
+            "duration": {
+                "type": "integer"
+            },
+            "startSchedule": {
+                "type": "string",
+                "format": "date-time"
+            },
+            "chargingRateUnit": {
+                "type": "string",
+                "additionalProperties": false,
+                "enum": [
+                    "A",
+                    "W"
+                    ]
+            },
+            "chargingSchedulePeriod": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "startPeriod": {
+                            "type": "integer"
+                        },
+                        "limit": {
+                            "type": "number",
+                            "multipleOf" : 0.1
+                        },
+                        "numberPhases": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "startPeriod",
+                        "limit"
+                        ]
+                }
+            },
+            "minChargingRate": {
+                "type": "number",
+                "multipleOf" : 0.1
+            }
+        },
+        "additionalProperties": false,
+        "required": [
+            "chargingRateUnit",
+            "chargingSchedulePeriod"
+        ]
+        }
+    },
     "additionalProperties": false,
     "required": [
         "status"

--- a/ocpp/v16/schemas/GetConfiguration.json
+++ b/ocpp/v16/schemas/GetConfiguration.json
@@ -7,7 +7,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-				"maxLength": 50
+                "maxLength": 50
             }
         }
     },

--- a/ocpp/v16/schemas/GetConfigurationResponse.json
+++ b/ocpp/v16/schemas/GetConfigurationResponse.json
@@ -10,16 +10,17 @@
                 "properties": {
                     "key": {
                         "type": "string",
-						"maxLength": 50
+                        "maxLength": 50
                     },
                     "readonly": {
                         "type": "boolean"
                     },
                     "value": {
                         "type": "string",
-						"maxLength": 500
+                        "maxLength": 500
                     }
                 },
+                "additionalProperties": false,
                 "required": [
                     "key",
                     "readonly"
@@ -30,7 +31,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-				"maxLength": 50
+                "maxLength": 50
             }
         }
     },

--- a/ocpp/v16/schemas/MeterValues.json
+++ b/ocpp/v16/schemas/MeterValues.json
@@ -18,124 +18,133 @@
                         "type": "string",
                         "format": "date-time"
                     },
-					"sampledValue": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
+                    "sampledValue": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
                                 "value": {
                                     "type": "string"
                                 },
-								"context": {
-									"type": "string",
-									"enum": [
-										"Interruption.Begin",
-										"Interruption.End",
-										"Sample.Clock",
-										"Sample.Periodic",
-										"Transaction.Begin",
-										"Transaction.End",
-										"Trigger",
-										"Other"
-									]
-								},
-								"format": {
-									"type": "string",
-									"enum": [
-										"Raw",
-										"SignedData"
-									]
-								},
-								"measurand": {
-									"type": "string",
-									"enum": [
-										"Energy.Active.Export.Register",
-										"Energy.Active.Import.Register",
-										"Energy.Reactive.Export.Register",
-										"Energy.Reactive.Import.Register",
-										"Energy.Active.Export.Interval",
-										"Energy.Active.Import.Interval",
-										"Energy.Reactive.Export.Interval",
-										"Energy.Reactive.Import.Interval",
-										"Power.Active.Export",
-										"Power.Active.Import",
-										"Power.Offered",
-										"Power.Reactive.Export",
-										"Power.Reactive.Import",
-										"Power.Factor",
-										"Current.Import",
-										"Current.Export",
-										"Current.Offered",
-										"Voltage",
-										"Frequency",
-										"Temperature",
-										"SoC",
-										"RPM"
-									]
-								},
-								"phase": {
-									"type": "string",
-									"enum": [
-										"L1",
-										"L2",
-										"L3",
-										"N",
-										"L1-N",
-										"L2-N",
-										"L3-N",
-										"L1-L2",
-										"L2-L3",
-										"L3-L1"
-									]
-								},
-								"location": {
-									"type": "string",
-									"enum": [
-										"Cable",
-										"EV",
-										"Inlet",
-										"Outlet",
-										"Body"
-									]
-								},
-								"unit": {
-									"type": "string",
-									"enum": [
-										"Wh",
-										"kWh",
-										"varh",
-										"kvarh",
-										"W",
-										"kW",
-										"VA",
-										"kVA",
-										"var",
-										"kvar",
-										"A",
-										"V",
-										"K",
-										"Celcius",
-										"Fahrenheit",
-										"Percent"
-									]
-								}
-							},
-							"required": [
-								"value"
-							]
-						}
-					}
-				},
+                                "context": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Interruption.Begin",
+                                        "Interruption.End",
+                                        "Sample.Clock",
+                                        "Sample.Periodic",
+                                        "Transaction.Begin",
+                                        "Transaction.End",
+                                        "Trigger",
+                                        "Other"
+                                    ]
+                                },
+                                "format": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Raw",
+                                        "SignedData"
+                                    ]
+                                },
+                                "measurand": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Energy.Active.Export.Register",
+                                        "Energy.Active.Import.Register",
+                                        "Energy.Reactive.Export.Register",
+                                        "Energy.Reactive.Import.Register",
+                                        "Energy.Active.Export.Interval",
+                                        "Energy.Active.Import.Interval",
+                                        "Energy.Reactive.Export.Interval",
+                                        "Energy.Reactive.Import.Interval",
+                                        "Power.Active.Export",
+                                        "Power.Active.Import",
+                                        "Power.Offered",
+                                        "Power.Reactive.Export",
+                                        "Power.Reactive.Import",
+                                        "Power.Factor",
+                                        "Current.Import",
+                                        "Current.Export",
+                                        "Current.Offered",
+                                        "Voltage",
+                                        "Frequency",
+                                        "Temperature",
+                                        "SoC",
+                                        "RPM"
+                                    ]
+                                },
+                                "phase": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "L1",
+                                        "L2",
+                                        "L3",
+                                        "N",
+                                        "L1-N",
+                                        "L2-N",
+                                        "L3-N",
+                                        "L1-L2",
+                                        "L2-L3",
+                                        "L3-L1"
+                                    ]
+                                },
+                                "location": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Cable",
+                                        "EV",
+                                        "Inlet",
+                                        "Outlet",
+                                        "Body"
+                                    ]
+                                },
+                                "unit": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Wh",
+                                        "kWh",
+                                        "varh",
+                                        "kvarh",
+                                        "W",
+                                        "kW",
+                                        "VA",
+                                        "kVA",
+                                        "var",
+                                        "kvar",
+                                        "A",
+                                        "V",
+                                        "K",
+                                        "Celcius",
+                                        "Celsius",
+                                        "Fahrenheit",
+                                        "Percent"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
                 "required": [
                     "timestamp",
-					"sampledValue"
-                ]		
-			}
-		}
+                    "sampledValue"
+                ]       
+            }
+        }
     },
     "additionalProperties": false,
     "required": [
         "connectorId",
-		"meterValue"
-	]
+        "meterValue"
+    ]
 }

--- a/ocpp/v16/schemas/RemoteStartTransaction.json
+++ b/ocpp/v16/schemas/RemoteStartTransaction.json
@@ -10,108 +10,115 @@
             "type": "string",
             "maxLength": 20
         },
-		"chargingProfile": {
-			"type": "object",
-			"properties": {
-				"chargingProfileId": {
-					"type": "integer"
-				},
-				"transactionId": {
-					"type": "integer"
-				},
-				"stackLevel": {
-					"type": "integer"
-				},
-				"chargingProfilePurpose": {
-					"type": "string",
-					"enum": [
-						"ChargePointMaxProfile",
-						"TxDefaultProfile",
-						"TxProfile"
-					]
-				},
-				"chargingProfileKind": {
-					"type": "string",
-					"enum": [
-						"Absolute",
-						"Recurring",
-						"Relative"
-					]
-				},
-				"recurrencyKind": {
-					"type": "string",
-					"enum": [
-						"Daily",
-						"Weekly"
-					]
-				},
-				"validFrom": {
-					"type": "string",
-					"format": "date-time"
-				},
-				"validTo": {
-					"type": "string",
-					"format": "date-time"
-				},
-				"chargingSchedule": {
-					"type": "object",
-					"properties": {
-						"duration": {
-							"type": "integer"
-						},
-						"startSchedule": {
-							"type": "string",
-							"format": "date-time"
-						},
-						"chargingRateUnit": {
-							"type": "string",
-							"enum": [
-								"A",
-								"W"
-							]
-						},
-						"chargingSchedulePeriod": {
-							"type": "array",
-							"items": {
-								"type": "object",
-								"properties": {
-									"startPeriod": {
-										"type": "integer"
-									},
-									"limit": {
-										"type": "number",
-										"multipleOf" : 0.1
-									},
-									"numberPhases": {
-										"type": "integer"
-									}
-								},
-								"required": [
-									"startPeriod",
-									"limit"
-								]
-							}
-						},
-						"minChargingRate": {
-							"type": "number",
-							"multipleOf" : 0.1
-						}
-					},
-					"required": [
-						"chargingRateUnit",
-						"chargingSchedulePeriod"
-					]
-				}
-			},
-			"required": [
-				"chargingProfileId",
-				"stackLevel",
-				"chargingProfilePurpose",
-				"chargingProfileKind",
-				"chargingSchedule"
-			]
-		}
-	},
+        "chargingProfile": {
+            "type": "object",
+            "properties": {
+                "chargingProfileId": {
+                    "type": "integer"
+                },
+                "transactionId": {
+                    "type": "integer"
+                },
+                "stackLevel": {
+                    "type": "integer"
+                },
+                "chargingProfilePurpose": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "ChargePointMaxProfile",
+                        "TxDefaultProfile",
+                        "TxProfile"
+                    ]
+                },
+                "chargingProfileKind": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Absolute",
+                        "Recurring",
+                        "Relative"
+                    ]
+                },
+                "recurrencyKind": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Daily",
+                        "Weekly"
+                    ]
+                },
+                "validFrom": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "validTo": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "chargingSchedule": {
+                    "type": "object",
+                    "properties": {
+                        "duration": {
+                            "type": "integer"
+                        },
+                        "startSchedule": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "chargingRateUnit": {
+                            "type": "string",
+                            "additionalProperties": false,
+                            "enum": [
+                                "A",
+                                "W"
+                            ]
+                        },
+                        "chargingSchedulePeriod": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "startPeriod": {
+                                        "type": "integer"
+                                    },
+                                    "limit": {
+                                        "type": "number",
+                                        "multipleOf" : 0.1
+                                    },
+                                    "numberPhases": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                    "startPeriod",
+                                    "limit"
+                                ]
+                            }
+                        },
+                        "minChargingRate": {
+                            "type": "number",
+                            "multipleOf" : 0.1
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "chargingRateUnit",
+                        "chargingSchedulePeriod"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "chargingProfileId",
+                "stackLevel",
+                "chargingProfilePurpose",
+                "chargingProfileKind",
+                "chargingSchedule"
+            ]
+        }
+    },
     "additionalProperties": false,
     "required": [
         "idTag"

--- a/ocpp/v16/schemas/RemoteStartTransactionResponse.json
+++ b/ocpp/v16/schemas/RemoteStartTransactionResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected"

--- a/ocpp/v16/schemas/RemoteStopTransactionResponse.json
+++ b/ocpp/v16/schemas/RemoteStopTransactionResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected"

--- a/ocpp/v16/schemas/ReserveNowResponse.json
+++ b/ocpp/v16/schemas/ReserveNowResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Faulted",

--- a/ocpp/v16/schemas/Reset.json
+++ b/ocpp/v16/schemas/Reset.json
@@ -5,6 +5,7 @@
     "properties": {
         "type": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Hard",
                 "Soft"

--- a/ocpp/v16/schemas/ResetResponse.json
+++ b/ocpp/v16/schemas/ResetResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected"

--- a/ocpp/v16/schemas/SendLocalList.json
+++ b/ocpp/v16/schemas/SendLocalList.json
@@ -17,17 +17,18 @@
                     },
                     "idTagInfo": {
                         "type": "object",
-						"expiryDate": {
-							"type": "string",
-							"format": "date-time"
-						},
-						"parentIdTag": {
-							"type": "string",
-							"maxLength": 20
-						},
                         "properties": {
+                            "expiryDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "parentIdTag": {
+                                "type": "string",
+                                "maxLength": 20
+                            },
                             "status": {
                                 "type": "string",
+                                "additionalProperties": false,
                                 "enum": [
                                     "Accepted",
                                     "Blocked",
@@ -37,18 +38,21 @@
                                 ]
                             }
                         },
+                        "additionalProperties": false,
                         "required": [
                             "status"
                         ]
                     }
                 },
+                "additionalProperties": false,
                 "required": [
                     "idTag"
                 ]
             }
         },
-		"updateType": {
+        "updateType": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Differential",
                 "Full"

--- a/ocpp/v16/schemas/SendLocalListResponse.json
+++ b/ocpp/v16/schemas/SendLocalListResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Failed",

--- a/ocpp/v16/schemas/SetChargingProfile.json
+++ b/ocpp/v16/schemas/SetChargingProfile.json
@@ -6,111 +6,118 @@
         "connectorId": {
             "type": "integer"
         },
-		"csChargingProfiles": {
-			"type": "object",
-			"properties": {
-				"chargingProfileId": {
-					"type": "integer"
-				},
-				"transactionId": {
-					"type": "integer"
-				},
-				"stackLevel": {
-					"type": "integer"
-				},
-				"chargingProfilePurpose": {
-					"type": "string",
-					"enum": [
-						"ChargePointMaxProfile",
-						"TxDefaultProfile",
-						"TxProfile"
-					]
-				},
-				"chargingProfileKind": {
-					"type": "string",
-					"enum": [
-						"Absolute",
-						"Recurring",
-						"Relative"
-					]
-				},
-				"recurrencyKind": {
-					"type": "string",
-					"enum": [
-						"Daily",
-						"Weekly"
-					]
-				},
-				"validFrom": {
-					"type": "string",
-					"format": "date-time"
-				},
-				"validTo": {
-					"type": "string",
-					"format": "date-time"
-				},
-				"chargingSchedule": {
-					"type": "object",
-					"properties": {
-						"duration": {
-							"type": "integer"
-						},
-						"startSchedule": {
-							"type": "string",
-							"format": "date-time"
-						},
-						"chargingRateUnit": {
-							"type": "string",
-							"enum": [
-								"A",
-								"W"
-							]
-						},
-						"chargingSchedulePeriod": {
-							"type": "array",
-							"items": {
-								"type": "object",
-								"properties": {
-									"startPeriod": {
-										"type": "integer"
-									},
-								"limit": {
-									"type": "number",
-									"multipleOf" : 0.1
-								},
-								"numberPhases": {
-										"type": "integer"
-									}
-								},
-								"required": [
-									"startPeriod",
-									"limit"
-								]
-							}
-						},
-						"minChargingRate": {
-							"type": "number",
-							"multipleOf" : 0.1
-						}
-					},
-					"required": [
-						"chargingRateUnit",
-						"chargingSchedulePeriod"
-					]
-				}
-			},
-			"required": [
-				"chargingProfileId",
-				"stackLevel",
-				"chargingProfilePurpose",
-				"chargingProfileKind",
-				"chargingSchedule"
-			]
-		}
+        "csChargingProfiles": {
+            "type": "object",
+            "properties": {
+                "chargingProfileId": {
+                    "type": "integer"
+                },
+                "transactionId": {
+                    "type": "integer"
+                },
+                "stackLevel": {
+                    "type": "integer"
+                },
+                "chargingProfilePurpose": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "ChargePointMaxProfile",
+                        "TxDefaultProfile",
+                        "TxProfile"
+                    ]
+                },
+                "chargingProfileKind": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Absolute",
+                        "Recurring",
+                        "Relative"
+                    ]
+                },
+                "recurrencyKind": {
+                    "type": "string",
+                    "additionalProperties": false,
+                    "enum": [
+                        "Daily",
+                        "Weekly"
+                    ]
+                },
+                "validFrom": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "validTo": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "chargingSchedule": {
+                    "type": "object",
+                    "properties": {
+                        "duration": {
+                            "type": "integer"
+                        },
+                        "startSchedule": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "chargingRateUnit": {
+                            "type": "string",
+                            "additionalProperties": false,
+                            "enum": [
+                                "A",
+                                "W"
+                            ]
+                        },
+                        "chargingSchedulePeriod": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "startPeriod": {
+                                        "type": "integer"
+                                    },
+                                "limit": {
+                                    "type": "number",
+                                    "multipleOf" : 0.1
+                                },
+                                "numberPhases": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "additionalProperties": false,
+                                "required": [
+                                    "startPeriod",
+                                    "limit"
+                                ]
+                            }
+                        },
+                        "minChargingRate": {
+                            "type": "number",
+                            "multipleOf" : 0.1
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "chargingRateUnit",
+                        "chargingSchedulePeriod"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "chargingProfileId",
+                "stackLevel",
+                "chargingProfilePurpose",
+                "chargingProfileKind",
+                "chargingSchedule"
+            ]
+        }
     },
     "additionalProperties": false,
     "required": [
         "connectorId",
-		"csChargingProfiles"
+        "csChargingProfiles"
     ]
 }

--- a/ocpp/v16/schemas/SetChargingProfileResponse.json
+++ b/ocpp/v16/schemas/SetChargingProfileResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected",

--- a/ocpp/v16/schemas/StartTransactionResponse.json
+++ b/ocpp/v16/schemas/StartTransactionResponse.json
@@ -16,6 +16,7 @@
                 },
                 "status": {
                     "type": "string",
+                    "additionalProperties": false,
                     "enum": [
                         "Accepted",
                         "Blocked",
@@ -25,11 +26,12 @@
                     ]
                 }
             },
+            "additionalProperties": false,
             "required": [
                 "status"
             ]
         },
-		"transactionId": {
+        "transactionId": {
             "type": "integer"
         }
     },

--- a/ocpp/v16/schemas/StatusNotification.json
+++ b/ocpp/v16/schemas/StatusNotification.json
@@ -8,6 +8,7 @@
         },
         "errorCode": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "ConnectorLockFailure",
                 "EVCommunicationError",
@@ -33,6 +34,7 @@
         },
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Available",
                 "Preparing",

--- a/ocpp/v16/schemas/StopTransaction.json
+++ b/ocpp/v16/schemas/StopTransaction.json
@@ -17,144 +17,154 @@
         "transactionId": {
             "type": "integer"
         },
-		"reason": {
-			"type": "string",
-			"enum": [
-				"EmergencyStop",
-				"EVDisconnected",
-				"HardReset",
-				"Local",
-				"Other",
-				"PowerLoss",
-				"Reboot",
-				"Remote",
-				"SoftReset",
-				"UnlockCommand",
-				"DeAuthorized"
-			]
-		},
-		"transactionData": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"timestamp": {
-						"type": "string",
-						"format": "date-time"
-					},
-					"sampledValue": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"value": {
-									"type": "string"
-								},
-								"context": {
-									"type": "string",
-									"enum": [
-										"Interruption.Begin",
-										"Interruption.End",
-										"Sample.Clock",
-										"Sample.Periodic",
-										"Transaction.Begin",
-										"Transaction.End",
-										"Trigger",
-										"Other"
-									]
-								},	
-								"format": {
-									"type": "string",
-									"enum": [
-										"Raw",
-										"SignedData"
-									]
-								},
-								"measurand": {
-									"type": "string",
-									"enum": [
-										"Energy.Active.Export.Register",
-										"Energy.Active.Import.Register",
-										"Energy.Reactive.Export.Register",
-										"Energy.Reactive.Import.Register",
-										"Energy.Active.Export.Interval",
-										"Energy.Active.Import.Interval",
-										"Energy.Reactive.Export.Interval",
-										"Energy.Reactive.Import.Interval",
-										"Power.Active.Export",
-										"Power.Active.Import",
-										"Power.Offered",
-										"Power.Reactive.Export",
-										"Power.Reactive.Import",
-										"Power.Factor",
-										"Current.Import",
-										"Current.Export",
-										"Current.Offered",
-										"Voltage",
-										"Frequency",
-										"Temperature",
-										"SoC",
-										"RPM"
-									]
-								},
-								"phase": {
-									"type": "string",
-									"enum": [
-										"L1",
-										"L2",
-										"L3",
-										"N",
-										"L1-N",
-										"L2-N",
-										"L3-N",
-										"L1-L2",
-										"L2-L3",
-										"L3-L1"
-									]
-								},
-								"location": {
-									"type": "string",
-									"enum": [
-										"Cable",
-										"EV",
-										"Inlet",
-										"Outlet",
-										"Body"
-									]
-								},
-								"unit": {
-									"type": "string",
-									"enum": [
-										"Wh",
-										"kWh",
-										"varh",
-										"kvarh",
-										"W",
-										"kW",
-										"VA",
-										"kVA",
-										"var",
-										"kvar",
-										"A",
-										"V",
-										"K",
-										"Celcius",
-										"Fahrenheit",
-										"Percent"
-									]
-								}
-							},
-							"required": [
-								"value"
-							]
-						}
-					}
-				},
-				"required": [
-					"timestamp",
-					"sampledValue"
-				]
-			}
+        "reason": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "EmergencyStop",
+                "EVDisconnected",
+                "HardReset",
+                "Local",
+                "Other",
+                "PowerLoss",
+                "Reboot",
+                "Remote",
+                "SoftReset",
+                "UnlockCommand",
+                "DeAuthorized"
+            ]
+        },
+        "transactionData": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "sampledValue": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string"
+                                },
+                                "context": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Interruption.Begin",
+                                        "Interruption.End",
+                                        "Sample.Clock",
+                                        "Sample.Periodic",
+                                        "Transaction.Begin",
+                                        "Transaction.End",
+                                        "Trigger",
+                                        "Other"
+                                    ]
+                                },  
+                                "format": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Raw",
+                                        "SignedData"
+                                    ]
+                                },
+                                "measurand": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Energy.Active.Export.Register",
+                                        "Energy.Active.Import.Register",
+                                        "Energy.Reactive.Export.Register",
+                                        "Energy.Reactive.Import.Register",
+                                        "Energy.Active.Export.Interval",
+                                        "Energy.Active.Import.Interval",
+                                        "Energy.Reactive.Export.Interval",
+                                        "Energy.Reactive.Import.Interval",
+                                        "Power.Active.Export",
+                                        "Power.Active.Import",
+                                        "Power.Offered",
+                                        "Power.Reactive.Export",
+                                        "Power.Reactive.Import",
+                                        "Power.Factor",
+                                        "Current.Import",
+                                        "Current.Export",
+                                        "Current.Offered",
+                                        "Voltage",
+                                        "Frequency",
+                                        "Temperature",
+                                        "SoC",
+                                        "RPM"
+                                    ]
+                                },
+                                "phase": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "L1",
+                                        "L2",
+                                        "L3",
+                                        "N",
+                                        "L1-N",
+                                        "L2-N",
+                                        "L3-N",
+                                        "L1-L2",
+                                        "L2-L3",
+                                        "L3-L1"
+                                    ]
+                                },
+                                "location": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Cable",
+                                        "EV",
+                                        "Inlet",
+                                        "Outlet",
+                                        "Body"
+                                    ]
+                                },
+                                "unit": {
+                                    "type": "string",
+                                    "additionalProperties": false,
+                                    "enum": [
+                                        "Wh",
+                                        "kWh",
+                                        "varh",
+                                        "kvarh",
+                                        "W",
+                                        "kW",
+                                        "VA",
+                                        "kVA",
+                                        "var",
+                                        "kvar",
+                                        "A",
+                                        "V",
+                                        "K",
+                                        "Celcius",
+                                        "Celsius",
+                                        "Fahrenheit",
+                                        "Percent"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "value"
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "timestamp",
+                    "sampledValue"
+                ]
+            }
         }
     },
     "additionalProperties": false,

--- a/ocpp/v16/schemas/StopTransactionResponse.json
+++ b/ocpp/v16/schemas/StopTransactionResponse.json
@@ -16,6 +16,7 @@
                 },
                 "status": {
                     "type": "string",
+                    "additionalProperties": false,
                     "enum": [
                         "Accepted",
                         "Blocked",
@@ -25,6 +26,7 @@
                     ]
                 }
             },
+            "additionalProperties": false,
             "required": [
                 "status"
             ]

--- a/ocpp/v16/schemas/TriggerMessage.json
+++ b/ocpp/v16/schemas/TriggerMessage.json
@@ -3,17 +3,18 @@
     "title": "TriggerMessageRequest",
     "type": "object",
     "properties": {
-		"requestedMessage": {
-				"type": "string",
-				"enum": [
-					"BootNotification",
-					"DiagnosticsStatusNotification",
-					"FirmwareStatusNotification",
-					"Heartbeat",
-					"MeterValues",
-					"StatusNotification"
-				]
-			},
+        "requestedMessage": {
+            "type": "string",
+            "additionalProperties": false,
+            "enum": [
+                "BootNotification",
+                "DiagnosticsStatusNotification",
+                "FirmwareStatusNotification",
+                "Heartbeat",
+                "MeterValues",
+                "StatusNotification"
+            ]
+        },
         "connectorId": {
             "type": "integer"
         }

--- a/ocpp/v16/schemas/TriggerMessageResponse.json
+++ b/ocpp/v16/schemas/TriggerMessageResponse.json
@@ -5,10 +5,11 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Accepted",
                 "Rejected",
-				"NotImplemented"
+                "NotImplemented"
             ]
         }
     },

--- a/ocpp/v16/schemas/UnlockConnectorResponse.json
+++ b/ocpp/v16/schemas/UnlockConnectorResponse.json
@@ -5,6 +5,7 @@
     "properties": {
         "status": {
             "type": "string",
+            "additionalProperties": false,
             "enum": [
                 "Unlocked",
                 "UnlockFailed",

--- a/ocpp/v16/schemas/UpdateFirmware.json
+++ b/ocpp/v16/schemas/UpdateFirmware.json
@@ -8,14 +8,14 @@
             "format": "uri"
         },
         "retries": {
-            "type": "number"
+            "type": "integer"
         },
         "retrieveDate": {
             "type": "string",
             "format": "date-time"
         },
         "retryInterval": {
-            "type": "number"
+            "type": "integer"
         }
     },
     "additionalProperties": false,


### PR DESCRIPTION


OCA has released new versions of the OCPP1.6 schemas together
with erratas.

This is the latest version published by OCA on 2019-12-05.
The only modifications from above are:
* Removal of id-fields (not handled by jsonschemas)
* Adding Celsius to the enum in StopTransaction.json.
  This was missed in the schema updates, but is according
  to the errata.

Fixes #57 (adding Celsius with correct spelling) and more.

Signed-off-by: Anders Darander <anders@chargestorm.se>