### PR TITLE
fix inheritance in enum classes

### DIFF
--- a/docs/source/central_system.rst
+++ b/docs/source/central_system.rst
@@ -102,7 +102,7 @@ Remove the `on_connect()` handler from the code above and replace it by the foll
            return call_result.BootNotificationPayload(
                current_time=datetime.utcnow().isoformat(),
                interval=10,
-               status=RegistrationStatus.accepted
+               status=RegistrationStatus.accepted.value
            )
 
 

--- a/examples/v16/central_system.py
+++ b/examples/v16/central_system.py
@@ -23,7 +23,7 @@ class ChargePoint(cp):
         return call_result.BootNotificationPayload(
 	    current_time=datetime.utcnow().isoformat(),
 	    interval=10,
-	    status=RegistrationStatus.accepted
+	    status=RegistrationStatus.accepted.value
 	)
 
 

--- a/examples/v16/charge_point.py
+++ b/examples/v16/charge_point.py
@@ -25,7 +25,7 @@ class ChargePoint(cp):
 
         response = await self.call(request)
 
-        if response.status ==  RegistrationStatus.accepted:
+        if response.status ==  RegistrationStatus.accepted.value:
             print("Connected to central system.")
 
 

--- a/ocpp/routing.py
+++ b/ocpp/routing.py
@@ -96,17 +96,17 @@ def create_route_map(obj):
             try:
                 action = getattr(attr, option)
 
-                if action not in routes:
-                    routes[action] = {}
+                if action.value not in routes:
+                    routes[action.value] = {}
 
                 # Routes decorated with the `@on()` decorator can be configured
                 # to skip validation of the input and output. For more info see
                 # the docstring of `on()`.
                 if option == '_on_action':
-                    routes[action]['_skip_schema_validation'] = \
+                    routes[action.value]['_skip_schema_validation'] = \
                         getattr(attr, '_skip_schema_validation', False)
 
-                routes[action][option] = attr
+                routes[action.value][option] = attr
 
             except AttributeError:
                 continue

--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -1,5 +1,6 @@
 import enum
 
+
 @enum.unique
 class Action(enum.Enum):
     """ An Action is a required part of a Call message. """

--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -1,4 +1,7 @@
-class Action:
+import enum
+
+@enum.unique
+class Action(enum.Enum):
     """ An Action is a required part of a Call message. """
     Authorize = "Authorize"
     BootNotification = "BootNotification"
@@ -12,7 +15,6 @@ class Action:
     FirmwareStatusNotification = "FirmwareStatusNotification"
     GetCompositeSchedule = "GetCompositeSchedule"
     GetConfiguration = "GetConfiguration"
-    ClearChargingProfile = "ClearChargingProfile"
     GetDiagnostics = "GetDiagnostics"
     GetLocalListVersion = "GetLocalListVersion"
     Heartbeat = "Heartbeat"
@@ -31,7 +33,8 @@ class Action:
     UpdateFirmware = "UpdateFirmware"
 
 
-class AuthorizationStatus:
+@enum.unique
+class AuthorizationStatus(enum.Enum):
     """
     Elements that constitute an entry of a Local Authorization List update.
     """
@@ -43,7 +46,8 @@ class AuthorizationStatus:
     concurrenttx = "ConcurrentTx"
 
 
-class AvailabilityStatus:
+@enum.unique
+class AvailabilityStatus(enum.Enum):
     """
     Status returned in response to ChangeAvailability.req.
     """
@@ -53,7 +57,8 @@ class AvailabilityStatus:
     scheduled = "Scheduled"
 
 
-class AvailabilityType:
+@enum.unique
+class AvailabilityType(enum.Enum):
     """
     Requested availability change in ChangeAvailability.req.
     """
@@ -62,7 +67,8 @@ class AvailabilityType:
     operative = "Operative"
 
 
-class CancelReservationStatus:
+@enum.unique
+class CancelReservationStatus(enum.Enum):
     """
     Status in CancelReservation.conf.
     """
@@ -71,7 +77,8 @@ class CancelReservationStatus:
     rejected = "Rejected"
 
 
-class ChargePointErrorCode:
+@enum.unique
+class ChargePointErrorCode(enum.Enum):
     """
     Charge Point status reported in StatusNotification.req.
     """
@@ -94,7 +101,8 @@ class ChargePointErrorCode:
     weakSignal = "WeakSignal"
 
 
-class ChargePointStatus:
+@enum.unique
+class ChargePointStatus(enum.Enum):
     """
     Status reported in StatusNotification.req. A status can be reported for
     the Charge Point main controller (connectorId = 0) or for a specific
@@ -117,7 +125,8 @@ class ChargePointStatus:
     faulted = "Faulted"
 
 
-class ChargingProfileKindType:
+@enum.unique
+class ChargingProfileKindType(enum.Enum):
     """
     "Absolute": Schedule periods are relative to a fixed point in time defined
                 in the schedule.
@@ -131,7 +140,8 @@ class ChargingProfileKindType:
     relative = "Relative"
 
 
-class ChargingProfilePurposeType:
+@enum.unique
+class ChargingProfilePurposeType(enum.Enum):
     """
     In load balancing scenarios, the Charge Point has one or more local
     charging profiles that limit the power or current to be shared by all
@@ -172,7 +182,8 @@ class ChargingProfilePurposeType:
     txprofile = "TxProfile"
 
 
-class ChargingProfileStatus:
+@enum.unique
+class ChargingProfileStatus(enum.Enum):
     """
     Status returned in response to SetChargingProfile.req.
     """
@@ -182,7 +193,8 @@ class ChargingProfileStatus:
     notSupported = "NotSupported"
 
 
-class ChargingRateUnitType:
+@enum.unique
+class ChargingRateUnitType(enum.Enum):
     """
     Unit in which a charging schedule is defined, as used in:
     GetCompositeSchedule.req and ChargingSchedule
@@ -192,7 +204,8 @@ class ChargingRateUnitType:
     amps = "A"
 
 
-class ClearCacheStatus:
+@enum.unique
+class ClearCacheStatus(enum.Enum):
     """
     Status returned in response to ClearCache.req.
     """
@@ -201,7 +214,8 @@ class ClearCacheStatus:
     rejected = "Rejected"
 
 
-class ClearChargingProfileStatus:
+@enum.unique
+class ClearChargingProfileStatus(enum.Enum):
     """
     Status returned in response to ClearChargingProfile.req.
     """
@@ -210,7 +224,8 @@ class ClearChargingProfileStatus:
     unknown = "Unknown"
 
 
-class ConfigurationStatus:
+@enum.unique
+class ConfigurationStatus(enum.Enum):
     """
     Status in ChangeConfiguration.conf.
     """
@@ -221,7 +236,8 @@ class ConfigurationStatus:
     notSupported = "NotSupported"
 
 
-class DataTransferStatus:
+@enum.unique
+class DataTransferStatus(enum.Enum):
     """
     Status in DataTransfer.conf.
     """
@@ -231,7 +247,8 @@ class DataTransferStatus:
     unknownVendorId = "UnknownVendorId"
 
 
-class DiagnosticsStatus:
+@enum.unique
+class DiagnosticsStatus(enum.Enum):
     """
     Status in DiagnosticsStatusNotification.req.
     """
@@ -242,7 +259,8 @@ class DiagnosticsStatus:
     uploading = "Uploading"
 
 
-class FirmwareStatus:
+@enum.unique
+class FirmwareStatus(enum.Enum):
     """
     Status of a firmware download as reported in FirmwareStatusNotification.req
     """
@@ -256,7 +274,8 @@ class FirmwareStatus:
     installed = "Installed"
 
 
-class GetCompositeScheduleStatus:
+@enum.unique
+class GetCompositeScheduleStatus(enum.Enum):
     """
     Status returned in response to GetCompositeSchedule.req
     """
@@ -265,7 +284,8 @@ class GetCompositeScheduleStatus:
     rejected = "Rejected"
 
 
-class Location:
+@enum.unique
+class Location(enum.Enum):
     """
     Allowable values of the optional "location" field of a value element in
     SampledValue.
@@ -278,7 +298,8 @@ class Location:
     ev = "EV"
 
 
-class Measurand:
+@enum.unique
+class Measurand(enum.Enum):
     """
     Allowable values of the optional "measurand" field of a Value element, as
     used in MeterValues.req and StopTransaction.req messages. Default value of
@@ -309,7 +330,8 @@ class Measurand:
     voltage = "Voltage"
 
 
-class MessageTrigger:
+@enum.unique
+class MessageTrigger(enum.Enum):
     """
     Type of request to be triggered in a TriggerMessage.req
     """
@@ -322,7 +344,8 @@ class MessageTrigger:
     statusNotification = "StatusNotification"
 
 
-class Phase:
+@enum.unique
+class Phase(enum.Enum):
     """
     Phase as used in SampledValue. Phase specifies how a measured value is to
     be interpreted. Please note that not all values of Phase are applicable to
@@ -341,7 +364,8 @@ class Phase:
     l3l1 = "L3-L1"
 
 
-class ReadingContext:
+@enum.unique
+class ReadingContext(enum.Enum):
     """
     Values of the context field of a value in SampledValue.
     """
@@ -356,7 +380,8 @@ class ReadingContext:
     trigger = "Trigger"
 
 
-class Reason:
+@enum.unique
+class Reason(enum.Enum):
     """
     Reason for stopping a transaction in StopTransaction.req.
     """
@@ -374,7 +399,8 @@ class Reason:
     deAuthorized = "DeAuthorized"
 
 
-class RecurrencyKind:
+@enum.unique
+class RecurrencyKindType(enum.Enum):
     """
     "Daily": The schedule restarts at the beginning of the next day.
     "Weekly": The schedule restarts at the beginning of the next week
@@ -385,7 +411,8 @@ class RecurrencyKind:
     weekly = "Weekly"
 
 
-class RegistrationStatus:
+@enum.unique
+class RegistrationStatus(enum.Enum):
     """
     Result of registration in response to BootNotification.req.
     """
@@ -395,7 +422,8 @@ class RegistrationStatus:
     rejected = "Rejected"
 
 
-class RemoteStartStopStatus:
+@enum.unique
+class RemoteStartStopStatus(enum.Enum):
     """
     The result of a RemoteStartTransaction.req or RemoteStopTransaction.req
     request.
@@ -404,7 +432,8 @@ class RemoteStartStopStatus:
     rejected = "Rejected"
 
 
-class ReservationStatus:
+@enum.unique
+class ReservationStatus(enum.Enum):
     """
     Status in ReserveNow.conf.
     """
@@ -416,7 +445,8 @@ class ReservationStatus:
     unavailable = "Unavailable"
 
 
-class ResetStatus:
+@enum.unique
+class ResetStatus(enum.Enum):
     """
     Result of Reset.req
     """
@@ -425,7 +455,8 @@ class ResetStatus:
     rejected = "Rejected"
 
 
-class ResetType:
+@enum.unique
+class ResetType(enum.Enum):
     """
     Type of reset requested by Reset.req
     """
@@ -434,7 +465,8 @@ class ResetType:
     soft = "Soft"
 
 
-class TriggerMessageStatus:
+@enum.unique
+class TriggerMessageStatus(enum.Enum):
     """
     Status in TriggerMessage.conf.
     """
@@ -444,7 +476,8 @@ class TriggerMessageStatus:
     notImplemented = "NotImplemented"
 
 
-class UnitOfMeasure:
+@enum.unique
+class UnitOfMeasure(enum.Enum):
     """
     Allowable values of the optional "unit" field of a Value element, as used
     in MeterValues.req and StopTransaction.req messages. Default value of
@@ -469,7 +502,8 @@ class UnitOfMeasure:
     percent = "Percent"
 
 
-class UnlockStatus:
+@enum.unique
+class UnlockStatus(enum.Enum):
     """
     Status in response to UnlockConnector.req.
     """
@@ -479,7 +513,8 @@ class UnlockStatus:
     notSupported = "NotSupported"
 
 
-class UpdateStatus:
+@enum.unique
+class UpdateStatus(enum.Enum):
     """
     Type of update for a SendLocalList.req.
     """
@@ -490,7 +525,8 @@ class UpdateStatus:
     versionMismatch = "VersionMismatch"
 
 
-class UpdateType:
+@enum.unique
+class UpdateType(enum.Enum):
     """
     Type of update for a SendLocalList.req.
     """
@@ -499,7 +535,8 @@ class UpdateType:
     full = "Full"
 
 
-class ValueFormat:
+@enum.unique
+class ValueFormat(enum.Enum):
     """
     Format that specifies how the value element in SampledValue is to be
     interpreted.

--- a/tests/v16/test_enums.py
+++ b/tests/v16/test_enums.py
@@ -3,311 +3,311 @@ from ocpp.v16.enums import *
 
 
 def test_authorization_status():
-    assert AuthorizationStatus.accepted == "Accepted"
-    assert AuthorizationStatus.blocked == "Blocked"
-    assert AuthorizationStatus.expired == "Expired"
-    assert AuthorizationStatus.invalid == "Invalid"
-    assert AuthorizationStatus.concurrenttx == "ConcurrentTx"
+    assert AuthorizationStatus.accepted.value == "Accepted"
+    assert AuthorizationStatus.blocked.value == "Blocked"
+    assert AuthorizationStatus.expired.value == "Expired"
+    assert AuthorizationStatus.invalid.value == "Invalid"
+    assert AuthorizationStatus.concurrenttx.value == "ConcurrentTx"
 
 
 def test_availability_status():
-    assert AvailabilityStatus.accepted == "Accepted"
-    assert AvailabilityStatus.rejected == "Rejected"
-    assert AvailabilityStatus.scheduled == "Scheduled"
+    assert AvailabilityStatus.accepted.value == "Accepted"
+    assert AvailabilityStatus.rejected.value == "Rejected"
+    assert AvailabilityStatus.scheduled.value == "Scheduled"
 
 
 def test_availability_type():
-    assert AvailabilityType.inoperative == "Inoperative"
-    assert AvailabilityType.operative == "Operative"
+    assert AvailabilityType.inoperative.value == "Inoperative"
+    assert AvailabilityType.operative.value == "Operative"
 
 
 def test_cancel_reservation_status():
-    assert CancelReservationStatus.accepted == "Accepted"
-    assert CancelReservationStatus.rejected == "Rejected"
+    assert CancelReservationStatus.accepted.value == "Accepted"
+    assert CancelReservationStatus.rejected.value == "Rejected"
 
 
 def test_charge_point_error_code():
-    assert (ChargePointErrorCode.connectorLockFailure ==
+    assert (ChargePointErrorCode.connectorLockFailure.value ==
             "ConnectorLockFailure")
-    assert (ChargePointErrorCode.evCommunicationError ==
+    assert (ChargePointErrorCode.evCommunicationError.value ==
             "EVCommunicationError")
-    assert ChargePointErrorCode.groundFailure == "GroundFailure"
-    assert (ChargePointErrorCode.highTemperature ==
+    assert ChargePointErrorCode.groundFailure.value == "GroundFailure"
+    assert (ChargePointErrorCode.highTemperature.value ==
             "HighTemperature")
-    assert ChargePointErrorCode.internalError == "InternalError"
-    assert (ChargePointErrorCode.localListConflict ==
+    assert ChargePointErrorCode.internalError.value == "InternalError"
+    assert (ChargePointErrorCode.localListConflict.value ==
             "LocalListConflict")
-    assert ChargePointErrorCode.noError == "NoError"
-    assert ChargePointErrorCode.otherError == "OtherError"
-    assert (ChargePointErrorCode.overCurrentFailure ==
+    assert ChargePointErrorCode.noError.value == "NoError"
+    assert ChargePointErrorCode.otherError.value == "OtherError"
+    assert (ChargePointErrorCode.overCurrentFailure.value ==
             "OverCurrentFailure")
-    assert ChargePointErrorCode.overVoltage == "OverVoltage"
-    assert (ChargePointErrorCode.powerMeterFailure ==
+    assert ChargePointErrorCode.overVoltage.value == "OverVoltage"
+    assert (ChargePointErrorCode.powerMeterFailure.value ==
             "PowerMeterFailure")
-    assert (ChargePointErrorCode.powerSwitchFailure ==
+    assert (ChargePointErrorCode.powerSwitchFailure.value ==
             "PowerSwitchFailure")
-    assert ChargePointErrorCode.readerFailure == "ReaderFailure"
-    assert ChargePointErrorCode.resetFailure == "ResetFailure"
-    assert ChargePointErrorCode.underVoltage == "UnderVoltage"
-    assert ChargePointErrorCode.weakSignal == "WeakSignal"
+    assert ChargePointErrorCode.readerFailure.value == "ReaderFailure"
+    assert ChargePointErrorCode.resetFailure.value == "ResetFailure"
+    assert ChargePointErrorCode.underVoltage.value == "UnderVoltage"
+    assert ChargePointErrorCode.weakSignal.value == "WeakSignal"
 
 
 def test_charge_point_status():
-    assert ChargePointStatus.available == 'Available'
-    assert ChargePointStatus.preparing == 'Preparing'
-    assert ChargePointStatus.charging == 'Charging'
-    assert ChargePointStatus.suspendedevse == 'SuspendedEVSE'
-    assert ChargePointStatus.suspendedev == 'SuspendedEV'
-    assert ChargePointStatus.finishing == 'Finishing'
-    assert ChargePointStatus.reserved == 'Reserved'
-    assert ChargePointStatus.unavailable == 'Unavailable'
-    assert ChargePointStatus.faulted == 'Faulted'
+    assert ChargePointStatus.available.value == 'Available'
+    assert ChargePointStatus.preparing.value == 'Preparing'
+    assert ChargePointStatus.charging.value == 'Charging'
+    assert ChargePointStatus.suspendedevse.value == 'SuspendedEVSE'
+    assert ChargePointStatus.suspendedev.value == 'SuspendedEV'
+    assert ChargePointStatus.finishing.value == 'Finishing'
+    assert ChargePointStatus.reserved.value == 'Reserved'
+    assert ChargePointStatus.unavailable.value == 'Unavailable'
+    assert ChargePointStatus.faulted.value == 'Faulted'
 
 
 def test_charging_profile_kind_type():
-    assert ChargingProfileKindType.absolute == 'Absolute'
-    assert ChargingProfileKindType.recurring == 'Recurring'
-    assert ChargingProfileKindType.relative == 'Relative'
+    assert ChargingProfileKindType.absolute.value == 'Absolute'
+    assert ChargingProfileKindType.recurring.value == 'Recurring'
+    assert ChargingProfileKindType.relative.value == 'Relative'
 
 
 def test_charging_profile_purpose_type():
-    assert (ChargingProfilePurposeType.chargepointmaxprofile ==
+    assert (ChargingProfilePurposeType.chargepointmaxprofile.value ==
             'ChargePointMaxProfile')
-    assert (ChargingProfilePurposeType.txdefaultprofile ==
+    assert (ChargingProfilePurposeType.txdefaultprofile.value ==
             'TxDefaultProfile')
-    assert ChargingProfilePurposeType.txprofile == 'TxProfile'
+    assert ChargingProfilePurposeType.txprofile.value == 'TxProfile'
 
 
 def test_charging_profile_status():
-    assert ChargingProfileStatus.accepted == "Accepted"
-    assert ChargingProfileStatus.rejected == "Rejected"
-    assert ChargingProfileStatus.notSupported == "NotSupported"
+    assert ChargingProfileStatus.accepted.value == "Accepted"
+    assert ChargingProfileStatus.rejected.value == "Rejected"
+    assert ChargingProfileStatus.notSupported.value == "NotSupported"
 
 
 def test_charging_rate_unit():
-    assert ChargingRateUnitType.watts == "W"
-    assert ChargingRateUnitType.amps == "A"
+    assert ChargingRateUnitType.watts.value == "W"
+    assert ChargingRateUnitType.amps.value == "A"
 
 
 def test_clear_cache_status():
-    assert ClearCacheStatus.accepted == "Accepted"
-    assert ClearCacheStatus.rejected == "Rejected"
+    assert ClearCacheStatus.accepted.value == "Accepted"
+    assert ClearCacheStatus.rejected.value == "Rejected"
 
 
 def test_clear_charging_profile_status():
-    assert ClearChargingProfileStatus.accepted == "Accepted"
-    assert ClearChargingProfileStatus.unknown == "Unknown"
+    assert ClearChargingProfileStatus.accepted.value == "Accepted"
+    assert ClearChargingProfileStatus.unknown.value == "Unknown"
 
 
 def test_configuration_status():
-    assert ConfigurationStatus.accepted == "Accepted"
-    assert ConfigurationStatus.rejected == "Rejected"
-    assert ConfigurationStatus.rebootRequired == "RebootRequired"
-    assert ConfigurationStatus.notSupported == "NotSupported"
+    assert ConfigurationStatus.accepted.value == "Accepted"
+    assert ConfigurationStatus.rejected.value == "Rejected"
+    assert ConfigurationStatus.rebootRequired.value == "RebootRequired"
+    assert ConfigurationStatus.notSupported.value == "NotSupported"
 
 
 def test_data_transfer_status():
-    assert DataTransferStatus.accepted == "Accepted"
-    assert DataTransferStatus.rejected == "Rejected"
-    assert (DataTransferStatus.unknownMessageId ==
+    assert DataTransferStatus.accepted.value == "Accepted"
+    assert DataTransferStatus.rejected.value == "Rejected"
+    assert (DataTransferStatus.unknownMessageId.value ==
             "UnknownMessageId")
-    assert DataTransferStatus.unknownVendorId == "UnknownVendorId"
+    assert DataTransferStatus.unknownVendorId.value == "UnknownVendorId"
 
 
 def test_diagnostics_status():
-    assert DiagnosticsStatus.idle == "Idle"
-    assert DiagnosticsStatus.uploaded == "Uploaded"
-    assert DiagnosticsStatus.uploadFailed == "UploadFailed"
-    assert DiagnosticsStatus.uploading == "Uploading"
+    assert DiagnosticsStatus.idle.value == "Idle"
+    assert DiagnosticsStatus.uploaded.value == "Uploaded"
+    assert DiagnosticsStatus.uploadFailed.value == "UploadFailed"
+    assert DiagnosticsStatus.uploading.value == "Uploading"
 
 
 def test_firmware_status():
-    assert FirmwareStatus.downloaded == "Downloaded"
-    assert FirmwareStatus.downloadFailed == "DownloadFailed"
-    assert FirmwareStatus.downloading == "Downloading"
-    assert FirmwareStatus.idle == "Idle"
-    assert (FirmwareStatus.installationFailed ==
+    assert FirmwareStatus.downloaded.value == "Downloaded"
+    assert FirmwareStatus.downloadFailed.value == "DownloadFailed"
+    assert FirmwareStatus.downloading.value == "Downloading"
+    assert FirmwareStatus.idle.value == "Idle"
+    assert (FirmwareStatus.installationFailed.value ==
             "InstallationFailed")
-    assert FirmwareStatus.installing == "Installing"
-    assert FirmwareStatus.installed == "Installed"
+    assert FirmwareStatus.installing.value == "Installing"
+    assert FirmwareStatus.installed.value == "Installed"
 
 
 def test_get_composite_schedule_status():
-    assert GetCompositeScheduleStatus.accepted == "Accepted"
-    assert GetCompositeScheduleStatus.rejected == "Rejected"
+    assert GetCompositeScheduleStatus.accepted.value == "Accepted"
+    assert GetCompositeScheduleStatus.rejected.value == "Rejected"
 
 
 def test_location():
-    assert Location.inlet == "Inlet"
-    assert Location.outlet == "Outlet"
-    assert Location.body == "Body"
-    assert Location.cable == "Cable"
-    assert Location.ev == "EV"
+    assert Location.inlet.value == "Inlet"
+    assert Location.outlet.value == "Outlet"
+    assert Location.body.value == "Body"
+    assert Location.cable.value == "Cable"
+    assert Location.ev.value == "EV"
 
 
 def test_measurand():
-    assert (Measurand.energyActiveExportRegister ==
+    assert (Measurand.energyActiveExportRegister.value ==
             "Energy.Active.Export.Register")
-    assert (Measurand.energyActiveImportRegister ==
+    assert (Measurand.energyActiveImportRegister.value ==
             "Energy.Active.Import.Register")
-    assert (Measurand.energyReactiveExportRegister ==
+    assert (Measurand.energyReactiveExportRegister.value ==
             "Energy.Reactive.Export.Register")
-    assert (Measurand.energyReactiveImportRegister ==
+    assert (Measurand.energyReactiveImportRegister.value ==
             "Energy.Reactive.Import.Register")
-    assert (Measurand.energyActiveExportInterval ==
+    assert (Measurand.energyActiveExportInterval.value ==
             "Energy.Active.Export.Interval")
-    assert (Measurand.energyActiveImportInterval ==
+    assert (Measurand.energyActiveImportInterval.value ==
             "Energy.Active.Import.Interval")
-    assert (Measurand.energyReactiveExportInterval ==
+    assert (Measurand.energyReactiveExportInterval.value ==
             "Energy.Reactive.Export.Interval")
-    assert (Measurand.energyReactiveImportInterval ==
+    assert (Measurand.energyReactiveImportInterval.value ==
             "Energy.Reactive.Import.Interval")
-    assert Measurand.frequency == "Frequency"
-    assert Measurand.powerActiveExport == "Power.Active.Export"
-    assert Measurand.powerActiveImport == "Power.Active.Import"
-    assert Measurand.powerFactor == "Power.Factor"
-    assert Measurand.powerOffered == "Power.Offered"
-    assert (Measurand.powerReactiveExport ==
+    assert Measurand.frequency.value == "Frequency"
+    assert Measurand.powerActiveExport.value == "Power.Active.Export"
+    assert Measurand.powerActiveImport.value == "Power.Active.Import"
+    assert Measurand.powerFactor.value == "Power.Factor"
+    assert Measurand.powerOffered.value == "Power.Offered"
+    assert (Measurand.powerReactiveExport.value ==
             "Power.Reactive.Export")
-    assert (Measurand.powerReactiveImport ==
+    assert (Measurand.powerReactiveImport.value ==
             "Power.Reactive.Import")
-    assert Measurand.currentExport == "Current.Export"
-    assert Measurand.currentImport == "Current.Import"
-    assert Measurand.currentOffered == "Current.Offered"
-    assert Measurand.rpm == "RPM"
-    assert Measurand.soc == "SoC"
-    assert Measurand.voltage == "Voltage"
-    assert Measurand.temperature == "Temperature"
+    assert Measurand.currentExport.value == "Current.Export"
+    assert Measurand.currentImport.value == "Current.Import"
+    assert Measurand.currentOffered.value == "Current.Offered"
+    assert Measurand.rpm.value == "RPM"
+    assert Measurand.soc.value == "SoC"
+    assert Measurand.voltage.value == "Voltage"
+    assert Measurand.temperature.value == "Temperature"
 
 
 def test_message_trigger():
-    assert MessageTrigger.bootNotification == "BootNotification"
-    assert (MessageTrigger.diagnosticsStatusNotification ==
+    assert MessageTrigger.bootNotification.value == "BootNotification"
+    assert (MessageTrigger.diagnosticsStatusNotification.value ==
             "DiagnosticsStatusNotification")
-    assert (MessageTrigger.firmwareStatusNotification ==
+    assert (MessageTrigger.firmwareStatusNotification.value ==
             "FirmwareStatusNotification")
-    assert MessageTrigger.heartbeat == "Heartbeat"
-    assert MessageTrigger.meterValues == "MeterValues"
-    assert (MessageTrigger.statusNotification ==
+    assert MessageTrigger.heartbeat.value == "Heartbeat"
+    assert MessageTrigger.meterValues.value == "MeterValues"
+    assert (MessageTrigger.statusNotification.value ==
             "StatusNotification")
 
 
 def test_phase():
-    assert Phase.l1 == "L1"
-    assert Phase.l2 == "L2"
-    assert Phase.l3 == "L3"
-    assert Phase.n == "N"
-    assert Phase.l1n == "L1-N"
-    assert Phase.l2n == "L2-N"
-    assert Phase.l3n == "L3-N"
-    assert Phase.l1l2 == "L1-L2"
-    assert Phase.l2l3 == "L2-L3"
-    assert Phase.l3l1 == "L3-L1"
+    assert Phase.l1.value == "L1"
+    assert Phase.l2.value == "L2"
+    assert Phase.l3.value == "L3"
+    assert Phase.n.value == "N"
+    assert Phase.l1n.value == "L1-N"
+    assert Phase.l2n.value == "L2-N"
+    assert Phase.l3n.value == "L3-N"
+    assert Phase.l1l2.value == "L1-L2"
+    assert Phase.l2l3.value == "L2-L3"
+    assert Phase.l3l1.value == "L3-L1"
 
 
 def test_reading_context():
-    assert (ReadingContext.interruptionBegin ==
+    assert (ReadingContext.interruptionBegin.value ==
             "Interruption.Begin")
-    assert ReadingContext.interruptionEnd == "Interruption.End"
-    assert ReadingContext.other == "Other"
-    assert ReadingContext.sampleClock == "Sample.Clock"
-    assert ReadingContext.samplePeriodic == "Sample.Periodic"
-    assert ReadingContext.transactionBegin == "Transaction.Begin"
-    assert ReadingContext.transactionEnd == "Transaction.End"
-    assert ReadingContext.trigger == "Trigger"
+    assert ReadingContext.interruptionEnd.value == "Interruption.End"
+    assert ReadingContext.other.value == "Other"
+    assert ReadingContext.sampleClock.value == "Sample.Clock"
+    assert ReadingContext.samplePeriodic.value == "Sample.Periodic"
+    assert ReadingContext.transactionBegin.value == "Transaction.Begin"
+    assert ReadingContext.transactionEnd.value == "Transaction.End"
+    assert ReadingContext.trigger.value == "Trigger"
 
 
 def test_reason():
-    assert Reason.emergencyStop == "EmergencyStop"
-    assert Reason.evDisconnected == "EVDisconnected"
-    assert Reason.hardReset == "HardReset"
-    assert Reason.local == "Local"
-    assert Reason.other == "Other"
-    assert Reason.powerLoss == "PowerLoss"
-    assert Reason.reboot == "Reboot"
-    assert Reason.remote == "Remote"
-    assert Reason.softReset == "SoftReset"
-    assert Reason.unlockCommand == "UnlockCommand"
-    assert Reason.deAuthorized == "DeAuthorized"
+    assert Reason.emergencyStop.value == "EmergencyStop"
+    assert Reason.evDisconnected.value == "EVDisconnected"
+    assert Reason.hardReset.value == "HardReset"
+    assert Reason.local.value == "Local"
+    assert Reason.other.value == "Other"
+    assert Reason.powerLoss.value == "PowerLoss"
+    assert Reason.reboot.value == "Reboot"
+    assert Reason.remote.value == "Remote"
+    assert Reason.softReset.value == "SoftReset"
+    assert Reason.unlockCommand.value == "UnlockCommand"
+    assert Reason.deAuthorized.value == "DeAuthorized"
 
 
 def test_recurrency_kind():
-    assert RecurrencyKind.daily == 'Daily'
-    assert RecurrencyKind.weekly == 'Weekly'
+    assert RecurrencyKindType.daily.value == 'Daily'
+    assert RecurrencyKindType.weekly.value == 'Weekly'
 
 
 def test_registration_status():
-    assert RegistrationStatus.accepted == "Accepted"
-    assert RegistrationStatus.pending == "Pending"
-    assert RegistrationStatus.rejected == "Rejected"
+    assert RegistrationStatus.accepted.value == "Accepted"
+    assert RegistrationStatus.pending.value == "Pending"
+    assert RegistrationStatus.rejected.value == "Rejected"
 
 
 def test_remote_start_stop_status():
-    assert RemoteStartStopStatus.accepted == "Accepted"
-    assert RemoteStartStopStatus.rejected == "Rejected"
+    assert RemoteStartStopStatus.accepted.value == "Accepted"
+    assert RemoteStartStopStatus.rejected.value == "Rejected"
 
 
 def test_reservation_status():
-    assert ReservationStatus.accepted == "Accepted"
-    assert ReservationStatus.faulted == "Faulted"
-    assert ReservationStatus.occupied == "Occupied"
-    assert ReservationStatus.rejected == "Rejected"
-    assert ReservationStatus.unavailable == "Unavailable"
+    assert ReservationStatus.accepted.value == "Accepted"
+    assert ReservationStatus.faulted.value == "Faulted"
+    assert ReservationStatus.occupied.value == "Occupied"
+    assert ReservationStatus.rejected.value == "Rejected"
+    assert ReservationStatus.unavailable.value == "Unavailable"
 
 
 def test_reset_status():
-    assert ResetStatus.accepted == "Accepted"
-    assert ResetStatus.rejected == "Rejected"
+    assert ResetStatus.accepted.value == "Accepted"
+    assert ResetStatus.rejected.value == "Rejected"
 
 
 def test_reset_type():
-    assert ResetType.hard == "Hard"
-    assert ResetType.soft == "Soft"
+    assert ResetType.hard.value == "Hard"
+    assert ResetType.soft.value == "Soft"
 
 
 def test_trigger_message_status():
-    assert TriggerMessageStatus.accepted == "Accepted"
-    assert TriggerMessageStatus.rejected == "Rejected"
-    assert TriggerMessageStatus.notImplemented == "NotImplemented"
+    assert TriggerMessageStatus.accepted.value == "Accepted"
+    assert TriggerMessageStatus.rejected.value == "Rejected"
+    assert TriggerMessageStatus.notImplemented.value == "NotImplemented"
 
 
 def test_unit_of_measure():
-    assert UnitOfMeasure.wh == "Wh"
-    assert UnitOfMeasure.kwh == "kWh"
-    assert UnitOfMeasure.varh == "varh"
-    assert UnitOfMeasure.kvarh == "kvarh"
-    assert UnitOfMeasure.w == "W"
-    assert UnitOfMeasure.kw == "kW"
-    assert UnitOfMeasure.va == "VA"
-    assert UnitOfMeasure.kva == "kVA"
-    assert UnitOfMeasure.var == "var"
-    assert UnitOfMeasure.kvar == "kvar"
-    assert UnitOfMeasure.a == "A"
-    assert UnitOfMeasure.v == "V"
-    assert UnitOfMeasure.celsius == "Celsius"
-    assert UnitOfMeasure.fahrenheit == "Fahrenheit"
-    assert UnitOfMeasure.k == "K"
-    assert UnitOfMeasure.percent == "Percent"
+    assert UnitOfMeasure.wh.value == "Wh"
+    assert UnitOfMeasure.kwh.value == "kWh"
+    assert UnitOfMeasure.varh.value == "varh"
+    assert UnitOfMeasure.kvarh.value == "kvarh"
+    assert UnitOfMeasure.w.value == "W"
+    assert UnitOfMeasure.kw.value == "kW"
+    assert UnitOfMeasure.va.value == "VA"
+    assert UnitOfMeasure.kva.value == "kVA"
+    assert UnitOfMeasure.var.value == "var"
+    assert UnitOfMeasure.kvar.value == "kvar"
+    assert UnitOfMeasure.a.value == "A"
+    assert UnitOfMeasure.v.value == "V"
+    assert UnitOfMeasure.celsius.value == "Celsius"
+    assert UnitOfMeasure.fahrenheit.value == "Fahrenheit"
+    assert UnitOfMeasure.k.value == "K"
+    assert UnitOfMeasure.percent.value == "Percent"
 
 
 def test_unlock_status():
-    assert UnlockStatus.unlocked == "Unlocked"
-    assert UnlockStatus.unlockFailed == "UnlockFailed"
-    assert UnlockStatus.notSupported == "NotSupported"
+    assert UnlockStatus.unlocked.value == "Unlocked"
+    assert UnlockStatus.unlockFailed.value == "UnlockFailed"
+    assert UnlockStatus.notSupported.value == "NotSupported"
 
 
 def test_update_status():
-    assert UpdateStatus.accepted == "Accepted"
-    assert UpdateStatus.failed == "Failed"
-    assert UpdateStatus.notSupported == "NotSupported"
-    assert UpdateStatus.versionMismatch == "VersionMismatch"
+    assert UpdateStatus.accepted.value == "Accepted"
+    assert UpdateStatus.failed.value == "Failed"
+    assert UpdateStatus.notSupported.value == "NotSupported"
+    assert UpdateStatus.versionMismatch.value == "VersionMismatch"
 
 
 def test_update_type():
-    assert UpdateType.differential == "Differential"
-    assert UpdateType.full == "Full"
+    assert UpdateType.differential.value == "Differential"
+    assert UpdateType.full.value == "Full"
 
 
 def test_value_format():
-    assert ValueFormat.raw == "Raw"
-    assert ValueFormat.signedData == "SignedData"
+    assert ValueFormat.raw.value == "Raw"
+    assert ValueFormat.signedData.value == "SignedData"


### PR DESCRIPTION
Warning, this change break other software with the assumption of "enum" classes are not python Enum. But it is necessary to apply the assumption of enum classes are python Enum in another framework like Django...

The main change is to obtain values, for example:

After:
>>> status=RegistrationStatus.accepted

before:
>>> status=RegistrationStatus.accepted.value

Regards,
Luis