### PR TITLE
Remove white space after separator

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -200,7 +200,11 @@ class Call:
             self.unique_id,
             self.action,
             self.payload,
-        ])
+        ],
+            # By default json.dumps() adds a white space after every separator.
+            # By setting the separator manually that can be avoided.
+            separators=(',', ':')
+        )
 
     def create_call_result(self, payload):
         call_result = CallResult(self.unique_id, payload)
@@ -271,7 +275,11 @@ class CallResult:
             self.message_type_id,
             self.unique_id,
             self.payload,
-        ])
+        ],
+            # By default json.dumps() adds a white space after every separator.
+            # By setting the separator manually that can be avoided.
+            separators=(',', ':')
+        )
 
     def __repr__(self):
         return f"<CallResult - unique_id={self.unique_id}, " \
@@ -309,7 +317,11 @@ class CallError:
             self.error_code,
             self.error_description,
             self.error_details,
-        ])
+        ],
+            # By default json.dumps() adds a white space after every separator.
+            # By setting the separator manually that can be avoided.
+            separators=(',', ':')
+        )
 
     def to_exception(self):
         """ Return the exception that corresponds to the CallError. """

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -49,7 +49,9 @@ async def test_route_message_with_existing_route(base_central_system,
                 'interval': 350,
                 'status': 'Accepted',
             }
-        ])
+        ],
+            separators=(',', ':')
+        )
     )
 
 
@@ -78,7 +80,9 @@ async def test_route_message_without_validation(base_central_system):
             # and 'chargePointModel'.
             "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223"
         }
-    ]))
+    ],
+        separators=(',', ':')
+    ))
 
     base_central_system._connection.send.call_args == \
         mock.call(json.dumps([
@@ -89,7 +93,9 @@ async def test_route_message_without_validation(base_central_system):
                 'interval': 350,
                 'status': 'Yolo',
             }
-        ]))
+        ],
+            separators=(',', ':')
+        ))
 
 
 @pytest.mark.asyncio

--- a/tests/v20/test_v20_charge_point.py
+++ b/tests/v20/test_v20_charge_point.py
@@ -52,7 +52,9 @@ async def test_route_message_with_existing_route(base_central_system,
                 'interval': 350,
                 'status': 'Accepted',
             }
-        ])
+        ],
+            separators=(',', ':')
+        )
     )
 
 


### PR DESCRIPTION
Several charge point vendors have problems JSON messages with spaces
after a separator. Separators are `,` and `:` in a JSON message.
This commit removes them.

Fixes: #63 