### PR TITLE
Fix JSON encoding of decimal.Decimal

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -141,6 +141,7 @@ class ChargePoint:
 
         if msg.message_type_id == MessageType.Call:
             await self._handle_call(msg)
+
         elif msg.message_type_id in \
                 [MessageType.CallResult, MessageType.CallError]:
             self._response_queue.put_nowait(msg)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import decimal
 from datetime import datetime
 
 from ocpp.v16.enums import Action
@@ -8,7 +9,8 @@ from ocpp.exceptions import (ValidationError, ProtocolError,
                              PropertyConstraintViolationError,
                              UnknownCallErrorCodeError)
 from ocpp.messages import (validate_payload, get_schema, _schemas, unpack,
-                           Call, CallError, CallResult, MessageType)
+                           Call, CallError, CallResult, MessageType,
+                           _DecimalEncoder)
 
 
 def test_unpack_with_invalid_json():
@@ -223,3 +225,10 @@ def test_creating_exception_from_call_error_with_unknown_error_code():
 
     with pytest.raises(UnknownCallErrorCodeError):
         call_error.to_exception()
+
+
+def test_serializing_decimal():
+    assert json.dumps(
+        [decimal.Decimal(2.000001)],
+        cls=_DecimalEncoder
+    ) == "[2.0]"


### PR DESCRIPTION
Version `0.6.0` forces validation of `Call`s before they are send to the
other end. The validation of `call.SetChargingProfilePayload` fails with
a TypeError. The charging profile contains a value of type
`decimal.Decimal` and this value cannot be serialized to JSON. The
problem can be demonstrated like this:

	>>> import decimal
	>>> import json
	>>> >>> json.dumps(decimal.Decimal(3))
	Traceback (most recent call last):
	  File "<stdin>", line 1, in <module>
	  File "/home/developer/.pyenv/versions/3.7.0/lib/python3.7/json/__init__.py", line 231, in dumps
	    return _default_encoder.encode(obj)
	  File "/home/developer/.pyenv/versions/3.7.0/lib/python3.7/json/encoder.py", line 199, in encode
	    chunks = self.iterencode(o, _one_shot=True)
	  File "/home/developer/.pyenv/versions/3.7.0/lib/python3.7/json/encoder.py", line 257, in iterencode
	    return _iterencode(o, 0)
	  File "/home/developer/.pyenv/versions/3.7.0/lib/python3.7/json/encoder.py", line 179, in default
	    raise TypeError(f'Object of type {o.__class__.__name__} '
	TypeError: Object of type Decimal is not JSON serializable

This bug has been fixed by creating a custom enconder for
`decimal.Decimal`.

Fixes: #68