### PR TITLE
Added Hertz as a valid unit of measure, added a test

### DIFF
--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -467,6 +467,7 @@ class UnitOfMeasure:
     fahrenheit = "Fahrenheit"
     k = "K"
     percent = "Percent"
+    hertz = "Hertz"
 
 
 class UnlockStatus:

--- a/ocpp/v16/schemas/MeterValues.json
+++ b/ocpp/v16/schemas/MeterValues.json
@@ -123,7 +123,8 @@
                                         "Celcius",
                                         "Celsius",
                                         "Fahrenheit",
-                                        "Percent"
+                                        "Percent",
+                                        "Hertz"
                                     ]
                                 }
                             },

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -232,3 +232,29 @@ def test_serializing_decimal():
         [decimal.Decimal(2.000001)],
         cls=_DecimalEncoder
     ) == "[2.0]"
+
+
+def test_validate_meter_values_hertz():
+    """
+    Tests that a unit of measure called "Hertz" is permitted in validation.
+    This was missing from the original 1.6 spec, but was added as an errata (see the
+    OCPP 1.6 Errata sheet, v4.0 Release, 2019-10-23 (on page 34).
+    """
+    message = Call(
+        unique_id="1234",
+        action="MeterValues",
+        payload={
+            'connectorId': 1,
+            'transactionId': 123456789,
+            'meterValue': [{
+                'timestamp': '2020-02-21T13:48:45.459756Z',
+                'sampledValue': [{
+                    "value": "50.0",
+                    "measurand": "Frequency",
+                    "unit": "Hertz",
+                }]
+            }]
+        }
+    )
+
+    validate_payload(message, ocpp_version="1.6")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -237,8 +237,8 @@ def test_serializing_decimal():
 def test_validate_meter_values_hertz():
     """
     Tests that a unit of measure called "Hertz" is permitted in validation.
-    This was missing from the original 1.6 spec, but was added as an errata (see the
-    OCPP 1.6 Errata sheet, v4.0 Release, 2019-10-23 (on page 34).
+    This was missing from the original 1.6 spec, but was added as an errata
+    (see the OCPP 1.6 Errata sheet, v4.0 Release, 2019-10-23, page 34).
     """
     message = Call(
         unique_id="1234",

--- a/tests/v16/test_enums.py
+++ b/tests/v16/test_enums.py
@@ -288,6 +288,7 @@ def test_unit_of_measure():
     assert UnitOfMeasure.fahrenheit == "Fahrenheit"
     assert UnitOfMeasure.k == "K"
     assert UnitOfMeasure.percent == "Percent"
+    assert UnitOfMeasure.hertz == "Hertz"
 
 
 def test_unlock_status():


### PR DESCRIPTION
Updated the MeterValues schema to allow a unit of measure called "Hertz".
This was missing from the original 1.6 spec, but was added as an errata (see the
OCPP 1.6 Errata sheet, v4.0 Release, 2019-10-23, on page 34).

We've seen this unit of measure used in MeterValues messages from a "Viridian"
brand charger (which uses Evnex OCPP firmware), and we were having to work
around it by skipping schema validation of MeterValues messages.
