### PR TITLE
Add repository and documentation links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ authors = [
 	"dx <dx@mobilityhouse.com>",
 	"Jan Vincke <jan.vincke@mobilityhouse.com>",
 ]
+repository = "https://github.com/mobilityhouse/ocpp"
+documentation = "https://ocpp.readthedocs.io/en/latest/"
 license = "MIT"
 readme = "README.rst"
 


### PR DESCRIPTION
This makes it possible to go from the PyPI page to relevant docs, without having to guess with a search engine :)