### PR TITLE
Enable logging in examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,12 +55,16 @@ code in the `Central System documentation_`.
 .. code-block:: python
 
    import asyncio
+   import logging
    import websockets
    from datetime import datetime
 
    from ocpp.routing import on
    from ocpp.v20 import ChargePoint as cp
    from ocpp.v20 import call_result
+
+   logging.basicConfig(level=logging.INFO)
+
 
    class ChargePoint(cp):
        @on('BootNotification')
@@ -102,10 +106,13 @@ Charge point
 .. code-block:: python
 
    import asyncio
+   import logging
    import websockets
 
    from ocpp.v20 import call
    from ocpp.v20 import ChargePoint as cp
+
+   logging.basicConfig(level=logging.INFO)
 
 
    class ChargePoint(cp):

--- a/examples/v16/central_system.py
+++ b/examples/v16/central_system.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime
 
 try:
@@ -16,15 +17,17 @@ from ocpp.v16 import ChargePoint as cp
 from ocpp.v16.enums import Action, RegistrationStatus
 from ocpp.v16 import call_result
 
+logging.basicConfig(level=logging.INFO)
+
 
 class ChargePoint(cp):
     @on(Action.BootNotification)
     def on_boot_notitication(self, charge_point_vendor, charge_point_model, **kwargs):
         return call_result.BootNotificationPayload(
-	    current_time=datetime.utcnow().isoformat(),
-	    interval=10,
-	    status=RegistrationStatus.accepted
-	)
+            current_time=datetime.utcnow().isoformat(),
+            interval=10,
+            status=RegistrationStatus.accepted
+        )
 
 
 async def on_connect(websocket, path):

--- a/examples/v16/charge_point.py
+++ b/examples/v16/charge_point.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 try:
     import websockets
@@ -14,6 +15,8 @@ except ModuleNotFoundError:
 from ocpp.v16 import call
 from ocpp.v16 import ChargePoint as cp
 from ocpp.v16.enums import RegistrationStatus
+
+logging.basicConfig(level=logging.INFO)
 
 
 class ChargePoint(cp):

--- a/examples/v20/central_system.py
+++ b/examples/v20/central_system.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime
 
 try:
@@ -14,6 +15,8 @@ except ModuleNotFoundError:
 from ocpp.routing import on
 from ocpp.v20 import ChargePoint as cp
 from ocpp.v20 import call_result
+
+logging.basicConfig(level=logging.INFO)
 
 
 class ChargePoint(cp):

--- a/examples/v20/charge_point.py
+++ b/examples/v20/charge_point.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 try:
     import websockets
@@ -13,6 +14,8 @@ except ModuleNotFoundError:
 
 from ocpp.v20 import call
 from ocpp.v20 import ChargePoint as cp
+
+logging.basicConfig(level=logging.INFO)
 
 
 class ChargePoint(cp):


### PR DESCRIPTION
In several issues it became clear that users didn't knew how to enable
logging for the package. Therefore I enabled INFO logging in all
examples.