### PR TITLE
Allow __str__ representation to print exceptions

### DIFF
--- a/ocpp/exceptions.py
+++ b/ocpp/exceptions.py
@@ -25,8 +25,8 @@ class OCPPError(Exception):
                f" details={self.details}>"
 
     def __str__(self):
-        return f"<{self.__class__.__name__} - description={self.description},"\
-               f" details={self.details}>"
+        return f"{self.__class__.__name__}: {self.description},"\
+               f" {self.details}"
 
 
 class NotImplementedError(OCPPError):

--- a/ocpp/exceptions.py
+++ b/ocpp/exceptions.py
@@ -24,6 +24,10 @@ class OCPPError(Exception):
         return f"<{self.__class__.__name__} - description={self.description},"\
                f" details={self.details}>"
 
+    def __str__(self):
+        return f"<{self.__class__.__name__} - description={self.description},"\
+               f" details={self.details}>"
+
 
 class NotImplementedError(OCPPError):
     code = "NotImplemented"


### PR DESCRIPTION
Issue description:

Currently, errors in ocpp.exceptions lack a __str__() implementation.
Therefore, the following code doesn't print the error:

```
try:
   // Something that raises an exception.
except ocpp.exceptions.OCPPError as e:
  logger.warning("Failed to do something: %s", e)
```

Closes #105 
