### PR TITLE
Python 3.8 warnings

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -1,8 +1,9 @@
+import asyncio
+import inspect
+import logging
+import uuid
 import re
 import time
-import logging
-import asyncio
-import uuid
 from dataclasses import asdict
 
 from ocpp.routing import create_route_map
@@ -181,7 +182,9 @@ class ChargePoint:
                                       "registered.")
 
         try:
-            response = await asyncio.coroutine(handler)(**snake_case_payload)
+            response = handler(**snake_case_payload)
+            if inspect.isawaitable(response):
+                response = await response
         except Exception as e:
             LOGGER.exception("Error while handling request '%s'", msg)
             response = msg.create_call_error(e).to_json()
@@ -213,8 +216,12 @@ class ChargePoint:
             handler = handlers['_after_action']
             # Create task to avoid blocking when making a call inside the
             # after handler
-            asyncio.ensure_future(
-                asyncio.coroutine(handler)(**snake_case_payload))
+            response = handler(**snake_case_payload)
+            if inspect.isawaitable(response):
+                response = await response
+                asyncio.ensure_future(
+                    response)
+            response
         except KeyError:
             # '_on_after' hooks are not required. Therefore ignore exception
             # when no '_on_after' hook is installed.

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -219,9 +219,7 @@ class ChargePoint:
             response = handler(**snake_case_payload)
             if inspect.isawaitable(response):
                 response = await response
-                asyncio.ensure_future(
-                    response)
-            response
+                asyncio.ensure_future(response)
         except KeyError:
             # '_on_after' hooks are not required. Therefore ignore exception
             # when no '_on_after' hook is installed.


### PR DESCRIPTION
Issue: https://github.com/mobilityhouse/ocpp/issues/95

in order to avoid the following warning:
```
/.../lib/python3.8/site-packages/ocpp/charge_point.py:184:
DeprecationWarning: "@coroutine" decorator is deprecated
since Python 3.8, use "async def" instead
response = await asyncio.coroutine(handler)(**snake_case_payload)
```

as the function can be a normal function or a coroutine, the
following check can be used to await the function.

```
response = handler(**snake_case_payload)
if inspect.isawaitable(response):
                 response = await response
```