### PR TITLE
Fix execution of async `@after()` handlers.

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -218,8 +218,7 @@ class ChargePoint:
             # after handler
             response = handler(**snake_case_payload)
             if inspect.isawaitable(response):
-                response = await response
-                asyncio.ensure_future(response)
+                await response
         except KeyError:
             # '_on_after' hooks are not required. Therefore ignore exception
             # when no '_on_after' hook is installed.

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -29,7 +29,7 @@ async def test_route_message_with_existing_route(base_central_system,
         )
 
     @after(Action.BootNotification)
-    def after_boot_notification(charge_point_model, charge_point_vendor,
+    async def after_boot_notification(charge_point_model, charge_point_vendor,
                                 **kwargs):  # noqa
         assert charge_point_vendor == "Alfen BV"
         assert charge_point_model == "ICU Eve Mini"


### PR DESCRIPTION
The response of the handler was passed to `asyncio.ensure_future()`
and that resulted in a `TypeError`.

```
Traceback (most recent call last):
  File "/home/developer/projects/tmh-ocpp/.env/lib/python3.8/site-packages/websockets/server.py", line 191, in handler
    await self.ws_handler(self, path)
  File "examples/v16/central_system.py", line 44, in on_connect
    await cp.start()
  File "/home/developer/projects/tmh-ocpp/.env/lib/python3.8/site-packages/ocpp/charge_point.py", line 126, in start
    await self.route_message(message)
  File "/home/developer/projects/tmh-ocpp/.env/lib/python3.8/site-packages/ocpp/charge_point.py", line 144, in route_message
    await self._handle_call(msg)
  File "/home/developer/projects/tmh-ocpp/.env/lib/python3.8/site-packages/ocpp/charge_point.py", line 222, in _handle_call
    asyncio.ensure_future(response)
  File "/home/developer/.pyenv/versions/3.8.0/lib/python3.8/asyncio/tasks.py", line 673, in ensure_future
    raise TypeError('An asyncio.Future, a coroutine or an awaitable is '
TypeError: An asyncio.Future, a coroutine or an awaitable is required
```

Fixes: #117 