### PR TITLE
Fix for Schneider Electric EVlink Smart Wallbox

### DIFF
--- a/ocpp/v16/schemas/BootNotification.json
+++ b/ocpp/v16/schemas/BootNotification.json
@@ -13,11 +13,11 @@
         },
         "chargePointSerialNumber": {
             "type": "string",
-            "maxLength": 25
+            "maxLength": 26
         },
         "chargeBoxSerialNumber": {
             "type": "string",
-            "maxLength": 25
+            "maxLength": 34
         },
         "firmwareVersion": {
             "type": "string",


### PR DESCRIPTION
EVlink Smart Wallbox needs a string with 26 characters for "chargePointSerialNumber" and a string with 34 characters for "chargeBoxSerialNumber" (each as a fixed length).

See issue #122 