### PR TITLE
[WIP] Handle call error #104

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -261,7 +261,7 @@ class ChargePoint:
 
         if response.message_type_id == MessageType.CallError:
             LOGGER.warning("Received a CALLError: %s'", response)
-            return
+            return response
         else:
             response.action = call.action
             validate_payload(response, self._ocpp_version)

--- a/ocpp/exceptions.py
+++ b/ocpp/exceptions.py
@@ -34,6 +34,7 @@ class NotImplementedError(OCPPError):
     default_description = "Request Action is recognized but not supported by \
                           the receiver"
 
+
 class InternalError(OCPPError):
     code = "InternalError"
     default_description = "An internal error occurred and the receiver was \

--- a/ocpp/exceptions.py
+++ b/ocpp/exceptions.py
@@ -34,7 +34,6 @@ class NotImplementedError(OCPPError):
     default_description = "Request Action is recognized but not supported by \
                           the receiver"
 
-
 class InternalError(OCPPError):
     code = "InternalError"
     default_description = "An internal error occurred and the receiver was \


### PR DESCRIPTION
This integrates the possibility to handle CallError messages without breaking backwards compatibility.

The implementor can decide on what todo with the Error message. 

## Central System code

```python
...

class ChargePoint(cp):
    @on(Action.BootNotification)
    def on_boot_notitication(self, charge_point_vendor: str, charge_point_model: str, **kwargs):
        raise InternalError("Autobots Rollout Failed")
```

## Charge Point Code
```python
...

class ChargePoint(cp):
    async def send_boot_notification(self):
        request = call.BootNotificationPayload(
            charge_point_model="Optimus",
            charge_point_vendor="The Mobility House"
        )

        response = await self.call(request)
        if response.message_type_id == MessageType.CallError:
            print(response)
            print("Error Code: ", response.error_code)
            print("Exception: ", response.to_exception())
            return
        if response.status == RegistrationStatus.accepted:
            print("Connected to central system.")
        else:
            print(response)
```