### PR TITLE
Issue 131: Add support for Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,15 @@ jobs:
           name: run tests
           command: make deps && make test
 
+  test-39:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - checkout
+      - run:
+          name: run tests
+          command: make deps && make test
+
 workflows:
     version: 2.1
     workflows:
@@ -37,3 +46,4 @@ workflows:
           - test-36
           - test-37
           - test-38
+          - test-39


### PR DESCRIPTION
Python 3.9 has been released and Travis
should run the test against this python version.

Signed-off-by: Laysa Uchoa <laysa.uchoa@gmail.com>