### PR TITLE
Converted all camelCase and PascalCase enums to snake_case, except Action enumeration

### DIFF
--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -42,7 +42,7 @@ class AuthorizationStatus(str, Enum):
     blocked = "Blocked"
     expired = "Expired"
     invalid = "Invalid"
-    concurrenttx = "ConcurrentTx"
+    concurrent_tx = "ConcurrentTx"
 
 
 class AvailabilityStatus(str, Enum):
@@ -78,22 +78,22 @@ class ChargePointErrorCode(str, Enum):
     Charge Point status reported in StatusNotification.req.
     """
 
-    connectorLockFailure = "ConnectorLockFailure"
-    evCommunicationError = "EVCommunicationError"
-    groundFailure = "GroundFailure"
-    highTemperature = "HighTemperature"
-    internalError = "InternalError"
-    localListConflict = "LocalListConflict"
-    noError = "NoError"
-    otherError = "OtherError"
-    overCurrentFailure = "OverCurrentFailure"
-    overVoltage = "OverVoltage"
-    powerMeterFailure = "PowerMeterFailure"
-    powerSwitchFailure = "PowerSwitchFailure"
-    readerFailure = "ReaderFailure"
-    resetFailure = "ResetFailure"
-    underVoltage = "UnderVoltage"
-    weakSignal = "WeakSignal"
+    connector_lock_failure = "ConnectorLockFailure"
+    ev_communication_error = "EVCommunicationError"
+    ground_failure = "GroundFailure"
+    high_temperature = "HighTemperature"
+    internal_error = "InternalError"
+    local_list_conflict = "LocalListConflict"
+    no_error = "NoError"
+    other_error = "OtherError"
+    over_current_failure = "OverCurrentFailure"
+    over_voltage = "OverVoltage"
+    power_meter_failure = "PowerMeterFailure"
+    power_switch_failure = "PowerSwitchFailure"
+    reader_failure = "ReaderFailure"
+    reset_failure = "ResetFailure"
+    under_voltage = "UnderVoltage"
+    weak_signal = "WeakSignal"
 
 
 class ChargePointStatus(str, Enum):
@@ -111,8 +111,8 @@ class ChargePointStatus(str, Enum):
     available = "Available"
     preparing = "Preparing"
     charging = "Charging"
-    suspendedevse = "SuspendedEVSE"
-    suspendedev = "SuspendedEV"
+    suspended_evse = "SuspendedEVSE"
+    suspended_ev = "SuspendedEV"
     finishing = "Finishing"
     reserved = "Reserved"
     unavailable = "Unavailable"
@@ -169,9 +169,9 @@ class ChargingProfilePurposeType(str, Enum):
     MUST be set to TxProfile.
     """
 
-    chargepointmaxprofile = "ChargePointMaxProfile"
-    txdefaultprofile = "TxDefaultProfile"
-    txprofile = "TxProfile"
+    charge_point_max_profile = "ChargePointMaxProfile"
+    tx_default_profile = "TxDefaultProfile"
+    tx_profile = "TxProfile"
 
 
 class ChargingProfileStatus(str, Enum):
@@ -181,7 +181,7 @@ class ChargingProfileStatus(str, Enum):
 
     accepted = "Accepted"
     rejected = "Rejected"
-    notSupported = "NotSupported"
+    not_supported = "NotSupported"
 
 
 class ChargingRateUnitType(str, Enum):
@@ -219,8 +219,8 @@ class ConfigurationStatus(str, Enum):
 
     accepted = "Accepted"
     rejected = "Rejected"
-    rebootRequired = "RebootRequired"
-    notSupported = "NotSupported"
+    reboot_required = "RebootRequired"
+    not_supported = "NotSupported"
 
 
 class DataTransferStatus(str, Enum):
@@ -229,8 +229,8 @@ class DataTransferStatus(str, Enum):
     """
     accepted = "Accepted"
     rejected = "Rejected"
-    unknownMessageId = "UnknownMessageId"
-    unknownVendorId = "UnknownVendorId"
+    unknown_message_id = "UnknownMessageId"
+    unknown_vendor_id = "UnknownVendorId"
 
 
 class DiagnosticsStatus(str, Enum):
@@ -240,7 +240,7 @@ class DiagnosticsStatus(str, Enum):
 
     idle = "Idle"
     uploaded = "Uploaded"
-    uploadFailed = "UploadFailed"
+    upload_failed = "UploadFailed"
     uploading = "Uploading"
 
 
@@ -250,10 +250,10 @@ class FirmwareStatus(str, Enum):
     """
 
     downloaded = "Downloaded"
-    downloadFailed = "DownloadFailed"
+    download_failed = "DownloadFailed"
     downloading = "Downloading"
     idle = "Idle"
-    installationFailed = "InstallationFailed"
+    installation_failed = "InstallationFailed"
     installing = "Installing"
     installed = "Installed"
 
@@ -287,24 +287,24 @@ class Measurand(str, Enum):
     "measurand" is always "Energy.Active.Import.Register"
     """
 
-    currentExport = "Current.Export"
-    currentImport = "Current.Import"
-    currentOffered = "Current.Offered"
-    energyActiveExportRegister = "Energy.Active.Export.Register"
-    energyActiveImportRegister = "Energy.Active.Import.Register"
-    energyReactiveExportRegister = "Energy.Reactive.Export.Register"
-    energyReactiveImportRegister = "Energy.Reactive.Import.Register"
-    energyActiveExportInterval = "Energy.Active.Export.Interval"
-    energyActiveImportInterval = "Energy.Active.Import.Interval"
-    energyReactiveExportInterval = "Energy.Reactive.Export.Interval"
-    energyReactiveImportInterval = "Energy.Reactive.Import.Interval"
+    current_export = "Current.Export"
+    current_import = "Current.Import"
+    current_offered = "Current.Offered"
+    energy_active_export_register = "Energy.Active.Export.Register"
+    energy_active_import_register = "Energy.Active.Import.Register"
+    energy_reactive_export_register = "Energy.Reactive.Export.Register"
+    energy_reactive_import_register = "Energy.Reactive.Import.Register"
+    energy_active_export_interval = "Energy.Active.Export.Interval"
+    energy_active_import_interval = "Energy.Active.Import.Interval"
+    energy_reactive_export_interval = "Energy.Reactive.Export.Interval"
+    energy_reactive_import_interval = "Energy.Reactive.Import.Interval"
     frequency = "Frequency"
-    powerActiveExport = "Power.Active.Export"
-    powerActiveImport = "Power.Active.Import"
-    powerFactor = "Power.Factor"
-    powerOffered = "Power.Offered"
-    powerReactiveExport = "Power.Reactive.Export"
-    powerReactiveImport = "Power.Reactive.Import"
+    power_active_export = "Power.Active.Export"
+    power_active_import = "Power.Active.Import"
+    power_factor = "Power.Factor"
+    power_offered = "Power.Offered"
+    power_reactive_export = "Power.Reactive.Export"
+    power_reactive_import = "Power.Reactive.Import"
     rpm = "RPM"
     soc = "SoC"
     temperature = "Temperature"
@@ -316,12 +316,12 @@ class MessageTrigger(str, Enum):
     Type of request to be triggered in a TriggerMessage.req
     """
 
-    bootNotification = "BootNotification"
-    diagnosticsStatusNotification = "DiagnosticsStatusNotification"
-    firmwareStatusNotification = "FirmwareStatusNotification"
+    boot_notification = "BootNotification"
+    diagnostics_status_notification = "DiagnosticsStatusNotification"
+    firmware_status_notification = "FirmwareStatusNotification"
     heartbeat = "Heartbeat"
-    meterValues = "MeterValues"
-    statusNotification = "StatusNotification"
+    meter_values = "MeterValues"
+    status_notification = "StatusNotification"
 
 
 class Phase(str, Enum):
@@ -335,12 +335,12 @@ class Phase(str, Enum):
     l2 = "L2"
     l3 = "L3"
     n = "N"
-    l1n = "L1-N"
-    l2n = "L2-N"
-    l3n = "L3-N"
-    l1l2 = "L1-L2"
-    l2l3 = "L2-L3"
-    l3l1 = "L3-L1"
+    l1_n = "L1-N"
+    l2_n = "L2-N"
+    l3_n = "L3-N"
+    l1_l2 = "L1-L2"
+    l2_l3 = "L2-L3"
+    l3_l1 = "L3-L1"
 
 
 class ReadingContext(str, Enum):
@@ -348,13 +348,13 @@ class ReadingContext(str, Enum):
     Values of the context field of a value in SampledValue.
     """
 
-    interruptionBegin = "Interruption.Begin"
-    interruptionEnd = "Interruption.End"
+    interruption_begin = "Interruption.Begin"
+    interruption_end = "Interruption.End"
     other = "Other"
-    sampleClock = "Sample.Clock"
-    samplePeriodic = "Sample.Periodic"
-    transactionBegin = "Transaction.Begin"
-    transactionEnd = "Transaction.End"
+    sample_clock = "Sample.Clock"
+    sample_periodic = "Sample.Periodic"
+    transaction_begin = "Transaction.Begin"
+    transaction_end = "Transaction.End"
     trigger = "Trigger"
 
 
@@ -363,17 +363,17 @@ class Reason(str, Enum):
     Reason for stopping a transaction in StopTransaction.req.
     """
 
-    emergencyStop = "EmergencyStop"
-    evDisconnected = "EVDisconnected"
-    hardReset = "HardReset"
+    emergency_stop = "EmergencyStop"
+    ev_disconnected = "EVDisconnected"
+    hard_reset = "HardReset"
     local = "Local"
     other = "Other"
-    powerLoss = "PowerLoss"
+    power_loss = "PowerLoss"
     reboot = "Reboot"
     remote = "Remote"
-    softReset = "SoftReset"
-    unlockCommand = "UnlockCommand"
-    deAuthorized = "DeAuthorized"
+    soft_reset = "SoftReset"
+    unlock_command = "UnlockCommand"
+    de_authorized = "DeAuthorized"
 
 
 class RecurrencyKind(str, Enum):
@@ -443,7 +443,7 @@ class TriggerMessageStatus(str, Enum):
 
     accepted = "Accepted"
     rejected = "Rejected"
-    notImplemented = "NotImplemented"
+    not_implemented = "NotImplemented"
 
 
 class UnitOfMeasure(str, Enum):
@@ -478,8 +478,8 @@ class UnlockStatus(str, Enum):
     """
 
     unlocked = "Unlocked"
-    unlockFailed = "UnlockFailed"
-    notSupported = "NotSupported"
+    unlock_failed = "UnlockFailed"
+    not_supported = "NotSupported"
 
 
 class UpdateStatus(str, Enum):
@@ -489,8 +489,8 @@ class UpdateStatus(str, Enum):
 
     accepted = "Accepted"
     failed = "Failed"
-    notSupported = "NotSupported"
-    versionMismatch = "VersionMismatch"
+    not_supported = "NotSupported"
+    version_mismatch = "VersionMismatch"
 
 
 class UpdateType(str, Enum):
@@ -509,4 +509,4 @@ class ValueFormat(str, Enum):
     """
 
     raw = "Raw"
-    signedData = "SignedData"
+    signed_data = "SignedData"

--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -95,6 +95,24 @@ class ChargePointErrorCode(str, Enum):
     under_voltage = "UnderVoltage"
     weak_signal = "WeakSignal"
 
+    # Soon to be deprecated enums
+    connectorLockFailure = "ConnectorLockFailure"
+    evCommunicationError = "EVCommunicationError"
+    groundFailure = "GroundFailure"
+    highTemperature = "HighTemperature"
+    internalError = "InternalError"
+    localListConflict = "LocalListConflict"
+    noError = "NoError"
+    otherError = "OtherError"
+    overCurrentFailure = "OverCurrentFailure"
+    overVoltage = "OverVoltage"
+    powerMeterFailure = "PowerMeterFailure"
+    powerSwitchFailure = "PowerSwitchFailure"
+    readerFailure = "ReaderFailure"
+    resetFailure = "ResetFailure"
+    underVoltage = "UnderVoltage"
+    weakSignal = "WeakSignal"
+
 
 class ChargePointStatus(str, Enum):
     """
@@ -117,6 +135,10 @@ class ChargePointStatus(str, Enum):
     reserved = "Reserved"
     unavailable = "Unavailable"
     faulted = "Faulted"
+
+    # Soon to be deprecated enums
+    suspendedevse = "SuspendedEVSE"
+    suspendedev = "SuspendedEV"
 
 
 class ChargingProfileKindType(str, Enum):
@@ -173,6 +195,11 @@ class ChargingProfilePurposeType(str, Enum):
     tx_default_profile = "TxDefaultProfile"
     tx_profile = "TxProfile"
 
+    # Soon to be deprecated enums
+    chargepointmaxprofile = "ChargePointMaxProfile"
+    txdefaultprofile = "TxDefaultProfile"
+    txprofile = "TxProfile"
+
 
 class ChargingProfileStatus(str, Enum):
     """
@@ -182,6 +209,8 @@ class ChargingProfileStatus(str, Enum):
     accepted = "Accepted"
     rejected = "Rejected"
     not_supported = "NotSupported"
+    # Soon to be deprecated enums
+    notSupported = "NotSupported"
 
 
 class ChargingRateUnitType(str, Enum):
@@ -222,6 +251,10 @@ class ConfigurationStatus(str, Enum):
     reboot_required = "RebootRequired"
     not_supported = "NotSupported"
 
+    # Soon to be deprecated enums
+    rebootRequired = "RebootRequired"
+    notSupported = "NotSupported"
+
 
 class DataTransferStatus(str, Enum):
     """
@@ -231,6 +264,10 @@ class DataTransferStatus(str, Enum):
     rejected = "Rejected"
     unknown_message_id = "UnknownMessageId"
     unknown_vendor_id = "UnknownVendorId"
+
+    # Soon to be deprecated enums
+    unknownMessageId = "UnknownMessageId"
+    unknownVendorId = "UnknownVendorId"
 
 
 class DiagnosticsStatus(str, Enum):
@@ -242,6 +279,9 @@ class DiagnosticsStatus(str, Enum):
     uploaded = "Uploaded"
     upload_failed = "UploadFailed"
     uploading = "Uploading"
+
+    # Soon to be deprecated enums
+    uploadFailed = "UploadFailed"
 
 
 class FirmwareStatus(str, Enum):
@@ -256,6 +296,10 @@ class FirmwareStatus(str, Enum):
     installation_failed = "InstallationFailed"
     installing = "Installing"
     installed = "Installed"
+
+    # Soon to be deprecated enums
+    downloadFailed = "DownloadFailed"
+    installationFailed = "InstallationFailed"
 
 
 class GetCompositeScheduleStatus(str, Enum):
@@ -310,6 +354,25 @@ class Measurand(str, Enum):
     temperature = "Temperature"
     voltage = "Voltage"
 
+    # Soon to be deprecated enums
+    currentExport = "Current.Export"
+    currentImport = "Current.Import"
+    currentOffered = "Current.Offered"
+    energyActiveExportRegister = "Energy.Active.Export.Register"
+    energyActiveImportRegister = "Energy.Active.Import.Register"
+    energyReactiveExportRegister = "Energy.Reactive.Export.Register"
+    energyReactiveImportRegister = "Energy.Reactive.Import.Register"
+    energyActiveExportInterval = "Energy.Active.Export.Interval"
+    energyActiveImportInterval = "Energy.Active.Import.Interval"
+    energyReactiveExportInterval = "Energy.Reactive.Export.Interval"
+    energyReactiveImportInterval = "Energy.Reactive.Import.Interval"
+    powerActiveExport = "Power.Active.Export"
+    powerActiveImport = "Power.Active.Import"
+    powerFactor = "Power.Factor"
+    powerOffered = "Power.Offered"
+    powerReactiveExport = "Power.Reactive.Export"
+    powerReactiveImport = "Power.Reactive.Import"
+
 
 class MessageTrigger(str, Enum):
     """
@@ -322,6 +385,13 @@ class MessageTrigger(str, Enum):
     heartbeat = "Heartbeat"
     meter_values = "MeterValues"
     status_notification = "StatusNotification"
+
+    # Soon to be deprecated enums
+    bootNotification = "BootNotification"
+    diagnosticsStatusNotification = "DiagnosticsStatusNotification"
+    firmwareStatusNotification = "FirmwareStatusNotification"
+    meterValues = "MeterValues"
+    statusNotification = "StatusNotification"
 
 
 class Phase(str, Enum):
@@ -342,6 +412,14 @@ class Phase(str, Enum):
     l2_l3 = "L2-L3"
     l3_l1 = "L3-L1"
 
+    # Soon to be deprecated enums
+    l1n = "L1-N"
+    l2n = "L2-N"
+    l3n = "L3-N"
+    l1l2 = "L1-L2"
+    l2l3 = "L2-L3"
+    l3l1 = "L3-L1"
+
 
 class ReadingContext(str, Enum):
     """
@@ -356,6 +434,14 @@ class ReadingContext(str, Enum):
     transaction_begin = "Transaction.Begin"
     transaction_end = "Transaction.End"
     trigger = "Trigger"
+
+    # Soon to be deprecated enums
+    interruptionBegin = "Interruption.Begin"
+    interruptionEnd = "Interruption.End"
+    sampleClock = "Sample.Clock"
+    samplePeriodic = "Sample.Periodic"
+    transactionBegin = "Transaction.Begin"
+    transactionEnd = "Transaction.End"
 
 
 class Reason(str, Enum):
@@ -374,6 +460,15 @@ class Reason(str, Enum):
     soft_reset = "SoftReset"
     unlock_command = "UnlockCommand"
     de_authorized = "DeAuthorized"
+
+    # Soon to be deprecated enums
+    emergencyStop = "EmergencyStop"
+    evDisconnected = "EVDisconnected"
+    hardReset = "HardReset"
+    powerLoss = "PowerLoss"
+    softReset = "SoftReset"
+    unlockCommand = "UnlockCommand"
+    deAuthorized = "DeAuthorized"
 
 
 class RecurrencyKind(str, Enum):
@@ -445,6 +540,9 @@ class TriggerMessageStatus(str, Enum):
     rejected = "Rejected"
     not_implemented = "NotImplemented"
 
+    # Soon to be deprecated enums
+    notImplemented = "NotImplemented"
+
 
 class UnitOfMeasure(str, Enum):
     """
@@ -481,6 +579,10 @@ class UnlockStatus(str, Enum):
     unlock_failed = "UnlockFailed"
     not_supported = "NotSupported"
 
+    # Soon to be deprecated enums
+    unlockFailed = "UnlockFailed"
+    notSupported = "NotSupported"
+
 
 class UpdateStatus(str, Enum):
     """
@@ -491,6 +593,10 @@ class UpdateStatus(str, Enum):
     failed = "Failed"
     not_supported = "NotSupported"
     version_mismatch = "VersionMismatch"
+
+    # Soon to be deprecated enums
+    notSupported = "NotSupported"
+    versionMismatch = "VersionMismatch"
 
 
 class UpdateType(str, Enum):
@@ -510,3 +616,6 @@ class ValueFormat(str, Enum):
 
     raw = "Raw"
     signed_data = "SignedData"
+
+    # Soon to be deprecated enums
+    signedData = "SignedData"

--- a/ocpp/v201/enums.py
+++ b/ocpp/v201/enums.py
@@ -103,7 +103,7 @@ class AuthorizationStatusType(str, Enum):
 
     accepted = "Accepted"
     blocked = "Blocked"
-    concurrentTx = "ConcurrentTx"
+    concurrent_tx = "ConcurrentTx"
     expired = "Expired"
     invalid = "Invalid"
     # Identifier is valid, but EV Driver doesn’t have enough credit to start
@@ -320,7 +320,7 @@ class ClearMonitoringStatusType(str, Enum):
 
     accepted = "Accepted"
     rejected = "Rejected"
-    notFound = "NotFound"
+    not_found = "NotFound"
 
 
 class ComponentCriterionType(str, Enum):
@@ -439,7 +439,7 @@ class DeleteCertificateStatusType(str, Enum):
     """
     accepted = "Accepted"
     failed = "Failed"
-    notFound = "NotFound"
+    not_found = "NotFound"
 
 
 class DisplayMessageStatusType(str, Enum):
@@ -547,7 +547,7 @@ class GetChargingProfileStatusType(str, Enum):
     getChargingProfilesGetChargingProfilesResponse
     """
     accepted = "Accepted"
-    noProfiles = "NoProfiles"
+    no_profiles = "NoProfiles"
 
 
 class GetDisplayMessagesStatusType(str, Enum):
@@ -650,8 +650,8 @@ class LogType(str, Enum):
     """
     LogEnumType is used by getLogGetLogRequest
     """
-    diagnosticsLog = "DiagnosticsLog"
-    securityLog = "SecurityLog"
+    diagnostics_log = "DiagnosticsLog"
+    security_log = "SecurityLog"
 
 
 class LogStatusType(str, Enum):
@@ -661,7 +661,7 @@ class LogStatusType(str, Enum):
 
     accepted = "Accepted"
     rejected = "Rejected"
-    acceptedCanceled = "AcceptedCanceled"
+    accepted_canceled = "AcceptedCanceled"
 
 
 class MeasurandType(str, Enum):
@@ -1182,7 +1182,7 @@ class UnitOfMeasureType(str, Enum):
     va = "VA"
     kva = "kVA"
     vah = "VAh"
-    kVAh = "kVAh"
+    kvah = "kVAh"
     var = "var"
     kvar = "kvar"
     varh = "varh"

--- a/tests/v16/test_enums.py
+++ b/tests/v16/test_enums.py
@@ -7,7 +7,7 @@ def test_authorization_status():
     assert AuthorizationStatus.blocked == "Blocked"
     assert AuthorizationStatus.expired == "Expired"
     assert AuthorizationStatus.invalid == "Invalid"
-    assert AuthorizationStatus.concurrenttx == "ConcurrentTx"
+    assert AuthorizationStatus.concurrent_tx == "ConcurrentTx"
 
 
 def test_availability_status():
@@ -27,37 +27,37 @@ def test_cancel_reservation_status():
 
 
 def test_charge_point_error_code():
-    assert (ChargePointErrorCode.connectorLockFailure ==
+    assert (ChargePointErrorCode.connector_lock_failure ==
             "ConnectorLockFailure")
-    assert (ChargePointErrorCode.evCommunicationError ==
+    assert (ChargePointErrorCode.ev_communication_error ==
             "EVCommunicationError")
-    assert ChargePointErrorCode.groundFailure == "GroundFailure"
-    assert (ChargePointErrorCode.highTemperature ==
+    assert ChargePointErrorCode.ground_failure == "GroundFailure"
+    assert (ChargePointErrorCode.high_temperature ==
             "HighTemperature")
-    assert ChargePointErrorCode.internalError == "InternalError"
-    assert (ChargePointErrorCode.localListConflict ==
+    assert ChargePointErrorCode.internal_error == "InternalError"
+    assert (ChargePointErrorCode.local_list_conflict ==
             "LocalListConflict")
-    assert ChargePointErrorCode.noError == "NoError"
-    assert ChargePointErrorCode.otherError == "OtherError"
-    assert (ChargePointErrorCode.overCurrentFailure ==
+    assert ChargePointErrorCode.no_error == "NoError"
+    assert ChargePointErrorCode.other_error == "OtherError"
+    assert (ChargePointErrorCode.over_current_failure ==
             "OverCurrentFailure")
-    assert ChargePointErrorCode.overVoltage == "OverVoltage"
-    assert (ChargePointErrorCode.powerMeterFailure ==
+    assert ChargePointErrorCode.over_voltage == "OverVoltage"
+    assert (ChargePointErrorCode.power_meter_failure ==
             "PowerMeterFailure")
-    assert (ChargePointErrorCode.powerSwitchFailure ==
+    assert (ChargePointErrorCode.power_switch_failure ==
             "PowerSwitchFailure")
-    assert ChargePointErrorCode.readerFailure == "ReaderFailure"
-    assert ChargePointErrorCode.resetFailure == "ResetFailure"
-    assert ChargePointErrorCode.underVoltage == "UnderVoltage"
-    assert ChargePointErrorCode.weakSignal == "WeakSignal"
+    assert ChargePointErrorCode.reader_failure == "ReaderFailure"
+    assert ChargePointErrorCode.reset_failure == "ResetFailure"
+    assert ChargePointErrorCode.under_voltage == "UnderVoltage"
+    assert ChargePointErrorCode.weak_signal == "WeakSignal"
 
 
 def test_charge_point_status():
     assert ChargePointStatus.available == 'Available'
     assert ChargePointStatus.preparing == 'Preparing'
     assert ChargePointStatus.charging == 'Charging'
-    assert ChargePointStatus.suspendedevse == 'SuspendedEVSE'
-    assert ChargePointStatus.suspendedev == 'SuspendedEV'
+    assert ChargePointStatus.suspended_evse == 'SuspendedEVSE'
+    assert ChargePointStatus.suspended_ev == 'SuspendedEV'
     assert ChargePointStatus.finishing == 'Finishing'
     assert ChargePointStatus.reserved == 'Reserved'
     assert ChargePointStatus.unavailable == 'Unavailable'
@@ -71,17 +71,17 @@ def test_charging_profile_kind_type():
 
 
 def test_charging_profile_purpose_type():
-    assert (ChargingProfilePurposeType.chargepointmaxprofile ==
+    assert (ChargingProfilePurposeType.charge_point_max_profile ==
             'ChargePointMaxProfile')
-    assert (ChargingProfilePurposeType.txdefaultprofile ==
+    assert (ChargingProfilePurposeType.tx_default_profile ==
             'TxDefaultProfile')
-    assert ChargingProfilePurposeType.txprofile == 'TxProfile'
+    assert ChargingProfilePurposeType.tx_profile == 'TxProfile'
 
 
 def test_charging_profile_status():
     assert ChargingProfileStatus.accepted == "Accepted"
     assert ChargingProfileStatus.rejected == "Rejected"
-    assert ChargingProfileStatus.notSupported == "NotSupported"
+    assert ChargingProfileStatus.not_supported == "NotSupported"
 
 
 def test_charging_rate_unit():
@@ -102,31 +102,31 @@ def test_clear_charging_profile_status():
 def test_configuration_status():
     assert ConfigurationStatus.accepted == "Accepted"
     assert ConfigurationStatus.rejected == "Rejected"
-    assert ConfigurationStatus.rebootRequired == "RebootRequired"
-    assert ConfigurationStatus.notSupported == "NotSupported"
+    assert ConfigurationStatus.reboot_required == "RebootRequired"
+    assert ConfigurationStatus.not_supported == "NotSupported"
 
 
 def test_data_transfer_status():
     assert DataTransferStatus.accepted == "Accepted"
     assert DataTransferStatus.rejected == "Rejected"
-    assert (DataTransferStatus.unknownMessageId ==
+    assert (DataTransferStatus.unknown_message_id ==
             "UnknownMessageId")
-    assert DataTransferStatus.unknownVendorId == "UnknownVendorId"
+    assert DataTransferStatus.unknown_vendor_id == "UnknownVendorId"
 
 
 def test_diagnostics_status():
     assert DiagnosticsStatus.idle == "Idle"
     assert DiagnosticsStatus.uploaded == "Uploaded"
-    assert DiagnosticsStatus.uploadFailed == "UploadFailed"
+    assert DiagnosticsStatus.upload_failed == "UploadFailed"
     assert DiagnosticsStatus.uploading == "Uploading"
 
 
 def test_firmware_status():
     assert FirmwareStatus.downloaded == "Downloaded"
-    assert FirmwareStatus.downloadFailed == "DownloadFailed"
+    assert FirmwareStatus.download_failed == "DownloadFailed"
     assert FirmwareStatus.downloading == "Downloading"
     assert FirmwareStatus.idle == "Idle"
-    assert (FirmwareStatus.installationFailed ==
+    assert (FirmwareStatus.installation_failed ==
             "InstallationFailed")
     assert FirmwareStatus.installing == "Installing"
     assert FirmwareStatus.installed == "Installed"
@@ -146,34 +146,34 @@ def test_location():
 
 
 def test_measurand():
-    assert (Measurand.energyActiveExportRegister ==
+    assert (Measurand.energy_active_export_register ==
             "Energy.Active.Export.Register")
-    assert (Measurand.energyActiveImportRegister ==
+    assert (Measurand.energy_active_import_register ==
             "Energy.Active.Import.Register")
-    assert (Measurand.energyReactiveExportRegister ==
+    assert (Measurand.energy_reactive_export_register ==
             "Energy.Reactive.Export.Register")
-    assert (Measurand.energyReactiveImportRegister ==
+    assert (Measurand.energy_reactive_import_register ==
             "Energy.Reactive.Import.Register")
-    assert (Measurand.energyActiveExportInterval ==
+    assert (Measurand.energy_active_export_interval ==
             "Energy.Active.Export.Interval")
-    assert (Measurand.energyActiveImportInterval ==
+    assert (Measurand.energy_active_import_interval ==
             "Energy.Active.Import.Interval")
-    assert (Measurand.energyReactiveExportInterval ==
+    assert (Measurand.energy_reactive_export_interval ==
             "Energy.Reactive.Export.Interval")
-    assert (Measurand.energyReactiveImportInterval ==
+    assert (Measurand.energy_reactive_import_interval ==
             "Energy.Reactive.Import.Interval")
     assert Measurand.frequency == "Frequency"
-    assert Measurand.powerActiveExport == "Power.Active.Export"
-    assert Measurand.powerActiveImport == "Power.Active.Import"
-    assert Measurand.powerFactor == "Power.Factor"
-    assert Measurand.powerOffered == "Power.Offered"
-    assert (Measurand.powerReactiveExport ==
+    assert Measurand.power_active_export == "Power.Active.Export"
+    assert Measurand.power_active_import == "Power.Active.Import"
+    assert Measurand.power_factor == "Power.Factor"
+    assert Measurand.power_offered == "Power.Offered"
+    assert (Measurand.power_reactive_export ==
             "Power.Reactive.Export")
-    assert (Measurand.powerReactiveImport ==
+    assert (Measurand.power_reactive_import ==
             "Power.Reactive.Import")
-    assert Measurand.currentExport == "Current.Export"
-    assert Measurand.currentImport == "Current.Import"
-    assert Measurand.currentOffered == "Current.Offered"
+    assert Measurand.current_export == "Current.Export"
+    assert Measurand.current_import == "Current.Import"
+    assert Measurand.current_offered == "Current.Offered"
     assert Measurand.rpm == "RPM"
     assert Measurand.soc == "SoC"
     assert Measurand.voltage == "Voltage"
@@ -181,14 +181,14 @@ def test_measurand():
 
 
 def test_message_trigger():
-    assert MessageTrigger.bootNotification == "BootNotification"
-    assert (MessageTrigger.diagnosticsStatusNotification ==
+    assert MessageTrigger.boot_notification == "BootNotification"
+    assert (MessageTrigger.diagnostics_status_notification ==
             "DiagnosticsStatusNotification")
-    assert (MessageTrigger.firmwareStatusNotification ==
+    assert (MessageTrigger.firmware_status_notification ==
             "FirmwareStatusNotification")
     assert MessageTrigger.heartbeat == "Heartbeat"
-    assert MessageTrigger.meterValues == "MeterValues"
-    assert (MessageTrigger.statusNotification ==
+    assert MessageTrigger.meter_values == "MeterValues"
+    assert (MessageTrigger.status_notification ==
             "StatusNotification")
 
 
@@ -197,38 +197,38 @@ def test_phase():
     assert Phase.l2 == "L2"
     assert Phase.l3 == "L3"
     assert Phase.n == "N"
-    assert Phase.l1n == "L1-N"
-    assert Phase.l2n == "L2-N"
-    assert Phase.l3n == "L3-N"
-    assert Phase.l1l2 == "L1-L2"
-    assert Phase.l2l3 == "L2-L3"
-    assert Phase.l3l1 == "L3-L1"
+    assert Phase.l1_n == "L1-N"
+    assert Phase.l2_n == "L2-N"
+    assert Phase.l3_n == "L3-N"
+    assert Phase.l1_l2 == "L1-L2"
+    assert Phase.l2_l3 == "L2-L3"
+    assert Phase.l3_l1 == "L3-L1"
 
 
 def test_reading_context():
-    assert (ReadingContext.interruptionBegin ==
+    assert (ReadingContext.interruption_begin ==
             "Interruption.Begin")
-    assert ReadingContext.interruptionEnd == "Interruption.End"
+    assert ReadingContext.interruption_end == "Interruption.End"
     assert ReadingContext.other == "Other"
-    assert ReadingContext.sampleClock == "Sample.Clock"
-    assert ReadingContext.samplePeriodic == "Sample.Periodic"
-    assert ReadingContext.transactionBegin == "Transaction.Begin"
-    assert ReadingContext.transactionEnd == "Transaction.End"
+    assert ReadingContext.sample_clock == "Sample.Clock"
+    assert ReadingContext.sample_periodic == "Sample.Periodic"
+    assert ReadingContext.transaction_begin == "Transaction.Begin"
+    assert ReadingContext.transaction_end == "Transaction.End"
     assert ReadingContext.trigger == "Trigger"
 
 
 def test_reason():
-    assert Reason.emergencyStop == "EmergencyStop"
-    assert Reason.evDisconnected == "EVDisconnected"
-    assert Reason.hardReset == "HardReset"
+    assert Reason.emergency_stop == "EmergencyStop"
+    assert Reason.ev_disconnected == "EVDisconnected"
+    assert Reason.hard_reset == "HardReset"
     assert Reason.local == "Local"
     assert Reason.other == "Other"
-    assert Reason.powerLoss == "PowerLoss"
+    assert Reason.power_loss == "PowerLoss"
     assert Reason.reboot == "Reboot"
     assert Reason.remote == "Remote"
-    assert Reason.softReset == "SoftReset"
-    assert Reason.unlockCommand == "UnlockCommand"
-    assert Reason.deAuthorized == "DeAuthorized"
+    assert Reason.soft_reset == "SoftReset"
+    assert Reason.unlock_command == "UnlockCommand"
+    assert Reason.de_authorized == "DeAuthorized"
 
 
 def test_recurrency_kind():
@@ -268,7 +268,7 @@ def test_reset_type():
 def test_trigger_message_status():
     assert TriggerMessageStatus.accepted == "Accepted"
     assert TriggerMessageStatus.rejected == "Rejected"
-    assert TriggerMessageStatus.notImplemented == "NotImplemented"
+    assert TriggerMessageStatus.not_implemented == "NotImplemented"
 
 
 def test_unit_of_measure():
@@ -293,15 +293,15 @@ def test_unit_of_measure():
 
 def test_unlock_status():
     assert UnlockStatus.unlocked == "Unlocked"
-    assert UnlockStatus.unlockFailed == "UnlockFailed"
-    assert UnlockStatus.notSupported == "NotSupported"
+    assert UnlockStatus.unlock_failed == "UnlockFailed"
+    assert UnlockStatus.not_supported == "NotSupported"
 
 
 def test_update_status():
     assert UpdateStatus.accepted == "Accepted"
     assert UpdateStatus.failed == "Failed"
-    assert UpdateStatus.notSupported == "NotSupported"
-    assert UpdateStatus.versionMismatch == "VersionMismatch"
+    assert UpdateStatus.not_supported == "NotSupported"
+    assert UpdateStatus.version_mismatch == "VersionMismatch"
 
 
 def test_update_type():
@@ -311,4 +311,4 @@ def test_update_type():
 
 def test_value_format():
     assert ValueFormat.raw == "Raw"
-    assert ValueFormat.signedData == "SignedData"
+    assert ValueFormat.signed_data == "SignedData"


### PR DESCRIPTION
The conversion in the ocpp1.6 includes also the old enums to ensure backwards compatibility 


fixes #114 