### PR TITLE
Log in to Docker hub to prevent being rate limited

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   test-36:
     docker:
       - image: circleci/python:3.6
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run:
@@ -15,6 +18,9 @@ jobs:
   test-37:
     docker:
       - image: circleci/python:3.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run:
@@ -24,6 +30,9 @@ jobs:
   test-38:
     docker:
       - image: circleci/python:3.8
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run:
@@ -33,6 +42,9 @@ jobs:
   test-39:
     docker:
       - image: circleci/python:3.9
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Docker hub is changing it's policy as of November 1 2020. It will start
to rate limit pulls of images for non-paying users. This repo relies on
Docker hub for it's automated tests. In order to avoid to be rated
limited this the CircleCI job should log in to Docker hub before pulling
the Python images.

Fixes: #150 