### PR TITLE
Optimize validation by caching `Draft4Validator`s

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -170,12 +170,13 @@ def get_validator(
     if ocpp_version == "2.0":
         schema_name += '_v1p0'
 
+    cache_key = schema_name + ocpp_version
+    if cache_key in _schemas:
+        return _schemas[cache_key]
+
     dir,  _ = os.path.split(os.path.realpath(__file__))
     relative_path = f'{schemas_dir}/schemas/{schema_name}.json'
     path = os.path.join(dir, relative_path)
-
-    if relative_path in _validators:
-        return _validators[relative_path]
 
     # The JSON schemas for OCPP 2.0 start with a byte order mark (BOM)
     # character. If no encoding is given, reading the schema would fail with:
@@ -184,9 +185,9 @@ def get_validator(
     with open(path, 'r', encoding='utf-8-sig') as f:
         data = f.read()
         validator = Draft4Validator(json.loads(data, parse_float=parse_float))
-        _validators[relative_path] = validator
+        _validators[cache_key] = validator
 
-    return _validators[relative_path]
+    return _validators[cache_key]
 
 
 def validate_payload(message, ocpp_version):

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -174,7 +174,7 @@ def get_validator(
     relative_path = f'{schemas_dir}/schemas/{schema_name}.json'
     path = os.path.join(dir, relative_path)
 
-    if relative_path in _schemas:
+    if relative_path in _validators:
         return _validators[relative_path]
 
     # The JSON schemas for OCPP 2.0 start with a byte order mark (BOM)

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -170,7 +170,7 @@ def get_validator(
     if ocpp_version == "2.0":
         schema_name += '_v1p0'
 
-    cache_key = schema_name + ocpp_version
+    cache_key = schema_name + '_' + ocpp_version
     if cache_key in _schemas:
         return _schemas[cache_key]
 

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Callable, Dict
 from dataclasses import asdict, is_dataclass
 
-from jsonschema import validate, Draft4Validator
+from jsonschema import Draft4Validator
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 
 from ocpp.exceptions import (OCPPError, FormatViolationError,

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -171,8 +171,8 @@ def get_validator(
         schema_name += '_v1p0'
 
     cache_key = schema_name + '_' + ocpp_version
-    if cache_key in _schemas:
-        return _schemas[cache_key]
+    if cache_key in _validators:
+        return _validators[cache_key]
 
     dir,  _ = os.path.split(os.path.realpath(__file__))
     relative_path = f'{schemas_dir}/schemas/{schema_name}.json'

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -3,9 +3,11 @@ also contain some helper functions for packing and unpacking messages.  """
 import os
 import json
 import decimal
+import warnings
+from typing import Callable, Dict
 from dataclasses import asdict, is_dataclass
 
-from jsonschema import validate
+from jsonschema import validate, Draft4Validator
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 
 from ocpp.exceptions import (OCPPError, FormatViolationError,
@@ -13,7 +15,8 @@ from ocpp.exceptions import (OCPPError, FormatViolationError,
                              ProtocolError, ValidationError,
                              UnknownCallErrorCodeError)
 
-_schemas = {}
+_schemas: Dict[str, Dict] = {}
+_validators: Dict[str, Draft4Validator] = {}
 
 
 class _DecimalEncoder(json.JSONEncoder):
@@ -101,6 +104,10 @@ def get_schema(message_type_id, action, ocpp_version, parse_float=float):
     is used to parse floats. It must be a callable taking 1 argument. By
     default it is `float()`, but certain schema's require `decimal.Decimal()`.
     """
+    warnings.warn(
+        "Depricated as of 0.8.1. Please use `ocpp.messages.get_validator()`."
+    )
+
     if ocpp_version not in ["1.6", "2.0", "2.0.1"]:
         raise ValueError
 
@@ -134,6 +141,54 @@ def get_schema(message_type_id, action, ocpp_version, parse_float=float):
     return _schemas[relative_path]
 
 
+def get_validator(
+        message_type_id: int,
+        action: str,
+        ocpp_version: str,
+        parse_float: Callable = float
+) -> Draft4Validator:
+    """
+    Read schema from disk and return as `Draft4Validator`. Instances will be
+    cached for performance reasons.
+
+    The `parse_float` argument can be used to set the conversion method that
+    is used to parse floats. It must be a callable taking 1 argument. By
+    default it is `float()`, but certain schema's require `decimal.Decimal()`.
+    """
+    if ocpp_version not in ["1.6", "2.0", "2.0.1"]:
+        raise ValueError
+
+    schemas_dir = 'v' + ocpp_version.replace('.', '')
+
+    schema_name = action
+    if message_type_id == MessageType.CallResult:
+        schema_name += 'Response'
+    elif message_type_id == MessageType.Call:
+        if ocpp_version in ["2.0", "2.0.1"]:
+            schema_name += 'Request'
+
+    if ocpp_version == "2.0":
+        schema_name += '_v1p0'
+
+    dir,  _ = os.path.split(os.path.realpath(__file__))
+    relative_path = f'{schemas_dir}/schemas/{schema_name}.json'
+    path = os.path.join(dir, relative_path)
+
+    if relative_path in _schemas:
+        return _validators[relative_path]
+
+    # The JSON schemas for OCPP 2.0 start with a byte order mark (BOM)
+    # character. If no encoding is given, reading the schema would fail with:
+    #
+    #     Unexpected UTF-8 BOM (decode using utf-8-sig):
+    with open(path, 'r', encoding='utf-8-sig') as f:
+        data = f.read()
+        validator = Draft4Validator(json.loads(data, parse_float=parse_float))
+        _validators[relative_path] = validator
+
+    return _validators[relative_path]
+
+
 def validate_payload(message, ocpp_version):
     """ Validate the payload of the message using JSON schemas. """
     if type(message) not in [Call, CallResult]:
@@ -164,7 +219,7 @@ def validate_payload(message, ocpp_version):
             (type(message) == CallResult and
                 message.action == ['GetCompositeSchedule'])
         ):
-            schema = get_schema(
+            validator = get_validator(
                 message.message_type_id, message.action,
                 ocpp_version, parse_float=decimal.Decimal
             )
@@ -173,7 +228,7 @@ def validate_payload(message, ocpp_version):
                 json.dumps(message.payload), parse_float=decimal.Decimal
             )
         else:
-            schema = get_schema(
+            validator = get_validator(
                 message.message_type_id, message.action, ocpp_version
             )
     except (OSError, json.JSONDecodeError) as e:
@@ -181,7 +236,7 @@ def validate_payload(message, ocpp_version):
                               f"'{message.action}': {e}")
 
     try:
-        validate(message.payload, schema)
+        validator.validate(message.payload)
     except SchemaValidationError as e:
         raise ValidationError(f"Payload '{message.payload} for action "
                               f"'{message.action}' is not valid: {e}")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -85,7 +85,7 @@ def test_get_validator_with_valid_name():
     """
     schema = get_validator(MessageType.Call, "Reset", ocpp_version="1.6")
 
-    assert schema == _validators["Reset1.6"]
+    assert schema == _validators["Reset_1.6"]
     assert schema.schema == {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "ResetRequest",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -86,7 +86,7 @@ def test_get_validator_with_valid_name():
     """
     schema = get_validator(MessageType.Call, "Reset", ocpp_version="1.6")
 
-    assert schema == _validators["v16/schemas/Reset.json"]
+    assert schema == _validators["Reset1.6"]
     assert schema.schema == {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "ResetRequest",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,15 +2,16 @@ import json
 import pytest
 import decimal
 from datetime import datetime
+from jsonschema import Draft4Validator
 
 from ocpp.v16.enums import Action
 from ocpp.exceptions import (ValidationError, ProtocolError,
                              FormatViolationError,
                              PropertyConstraintViolationError,
                              UnknownCallErrorCodeError)
-from ocpp.messages import (validate_payload, get_schema, _schemas, unpack,
-                           Call, CallError, CallResult, MessageType,
-                           _DecimalEncoder)
+from ocpp.messages import (validate_payload, get_schema, _schemas,
+                           get_validator, _validators, unpack, Call, CallError,
+                           CallResult, MessageType, _DecimalEncoder)
 
 
 def test_unpack_with_invalid_json():
@@ -59,6 +60,34 @@ def test_get_schema_with_valid_name():
 
     assert schema == _schemas["v16/schemas/Reset.json"]
     assert schema == {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "ResetRequest",
+        "type": "object",
+        "properties": {
+            "type": {
+                'additionalProperties': False,
+                "type": "string",
+                "enum": [
+                    "Hard",
+                    "Soft"
+                ]
+            }
+        },
+        "additionalProperties": False,
+        "required": [
+            "type"
+        ]
+    }
+
+
+def test_get_validator_with_valid_name():
+    """
+    Test if correct validator is returned and if validator is added to cache.
+    """
+    schema = get_validator(MessageType.Call, "Reset", ocpp_version="1.6")
+
+    assert schema == _validators["v16/schemas/Reset.json"]
+    assert schema.schema == {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "ResetRequest",
         "type": "object",

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,7 +2,6 @@ import json
 import pytest
 import decimal
 from datetime import datetime
-from jsonschema import Draft4Validator
 
 from ocpp.v16.enums import Action
 from ocpp.exceptions import (ValidationError, ProtocolError,


### PR DESCRIPTION
Creating a `Draft4Validator` instance from a dict representation of a
JSON schema is pretty expensive. Therefore caching the instances makes
sense.

I've done some micro benchmarks. Below are the results:

![before](https://user-images.githubusercontent.com/1565144/99087761-6ea79f80-25cb-11eb-8a2a-116e5be789d0.png)
![Screenshot_2020-11-13_17-13-16](https://user-images.githubusercontent.com/1565144/99094342-fa252e80-25d3-11eb-821e-d362d706eaf2.png)



As expected benchmarks `test_xxxx_with_validation` show an significant performance improvement. 
`test_meter_values_with_validation` is 1.88 times faster.
`test_boot_notifications_with_validation` is 2.60  times faster.

Fixes: #154 