### PR TITLE
Add dataclasses for ChargingProfile and it's constituents

### DIFF
--- a/ocpp/v16/call.py
+++ b/ocpp/v16/call.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
 
@@ -5,12 +6,14 @@ from ocpp.v16.enums import (
     AvailabilityType,
     ChargePointErrorCode,
     ChargePointStatus,
+    ChargingProfileKindType,
     ChargingProfilePurposeType,
     ChargingRateUnitType,
     DiagnosticsStatus,
     FirmwareStatus,
     MessageTrigger,
     Reason,
+    RecurrencyKind,
     ResetType,
     UpdateType,
 )
@@ -123,9 +126,44 @@ class SendLocalListPayload:
 
 
 @dataclass
+class ChargingSchedulePeriod:
+    """Charging schedule period structure defines a time period in a charging schedule, as used in: ChargingSchedule."""
+    start_period: int
+    limit: Decimal
+    number_phases: Optional[int] = None
+
+
+@dataclass
+class ChargingSchedule:
+    """Charging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and
+    ChargingProfile."""
+
+    charging_rate_unit: ChargingRateUnitType
+    charging_schedule_period: List[ChargingSchedulePeriod]
+    duration: Optional[int] = None
+    start_schedule: Optional[str] = None
+    min_charging_rate: Optional[Decimal] = None
+
+
+@dataclass
+class ChargingProfile:
+    """A ChargingProfile consists of a ChargingSchedule, describing the amount of power or current that can be
+    delivered per time interval."""
+    charging_profile_id: int
+    stack_level: int
+    charging_profile_purpose: ChargingProfilePurposeType
+    charging_profile_kind: ChargingProfileKindType
+    charging_schedule: ChargingSchedule
+    transaction_id: Optional[int] = None
+    recurrency_kind: Optional[RecurrencyKind] = None
+    valid_from: Optional[str] = None
+    valid_to: Optional[str] = None
+
+
+@dataclass
 class SetChargingProfilePayload:
     connector_id: int
-    cs_charging_profiles: Dict
+    cs_charging_profiles: ChargingProfile
 
 
 @dataclass


### PR DESCRIPTION
Some questions:

* These objects don't quite fit into calls, because they're not call payloads. On the other hand, they don't really fit in Enums either. I considered adding a new file like `types.py`, but figured it best to see what your preference is?

* I also wanted to add a check to ensure a SetChargingProfilePayload is serialised to the correct representation when using these objects. I noticed the codebase doesn't have such tests for other payloads, so I left it. Would you like to keep it this way?

Thanks!