### PR TITLE
Fix `UnboundLocalError` in examples

### DIFF
--- a/examples/v16/central_system.py
+++ b/examples/v16/central_system.py
@@ -38,8 +38,10 @@ async def on_connect(websocket, path):
         requested_protocols = websocket.request_headers[
             'Sec-WebSocket-Protocol']
     except KeyError:
-        logging.info("Client hasn't requested any Subprotocol. "
-                     "Closing Connection")
+        logging.error(
+            "Client hasn't requested any Subprotocol. Closing Connection"
+        )
+        return await websocket.close()
     if websocket.subprotocol:
         logging.info("Protocols Matched: %s", websocket.subprotocol)
     else:

--- a/examples/v20/central_system.py
+++ b/examples/v20/central_system.py
@@ -44,8 +44,10 @@ async def on_connect(websocket, path):
         requested_protocols = websocket.request_headers[
             'Sec-WebSocket-Protocol']
     except KeyError:
-        logging.info("Client hasn't requested any Subprotocol. "
-                     "Closing Connection")
+        logging.error(
+            "Client hasn't requested any Subprotocol. Closing Connection"
+        )
+        return await websocket.close()
     if websocket.subprotocol:
         logging.info("Protocols Matched: %s", websocket.subprotocol)
     else:

--- a/examples/v201/central_system.py
+++ b/examples/v201/central_system.py
@@ -47,6 +47,10 @@ async def on_connect(websocket, path):
         logging.info("Client hasn't requested any Subprotocol. "
                      "Closing Connection")
         return await websocket.close()
+        logging.error(
+            "Client hasn't requested any Subprotocol. Closing Connection"
+        )
+        return await websocket.close()
     if websocket.subprotocol:
         logging.info("Protocols Matched: %s", websocket.subprotocol)
     else:


### PR DESCRIPTION
The examples for the central systems contained a bug. This bug could
lead to a `UnboundLocalError` if a client wouldn't send a
`Sec-WebSocket-Protocol` along with the websocket handshake.

```
ERROR:websockets.server:Error in connection handler
Traceback (most recent call last):
  File "/home/developer/projects/tmh-ocpp/.env/lib/python3.8/site-packages/websockets/server.py", line 191, in handler
    await self.ws_handler(self, path)
  File "examples/v16/central_system.py", line 54, in on_connect
    requested_protocols)
UnboundLocalError: local variable 'requested_protocols' referenced before assignment
```

Fixes #178