### PR TITLE
handle exception in route_message

### DIFF
--- a/examples/v201/central_system.py
+++ b/examples/v201/central_system.py
@@ -65,8 +65,10 @@ async def on_connect(websocket, path):
 
     charge_point_id = path.strip('/')
     charge_point = ChargePoint(charge_point_id, websocket)
-
-    await charge_point.start()
+    try:
+        await charge_point.start()
+    except Exception as e:
+        logging.exception(e)
 
 
 async def main():

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -123,7 +123,11 @@ class ChargePoint:
             message = await self._connection.recv()
             LOGGER.info('%s: receive message %s', self.id, message)
 
-            await self.route_message(message)
+            try:
+                await self.route_message(message)
+            except Exception as e:
+                LOGGER.exception(e)
+
 
     async def route_message(self, raw_msg):
         """
@@ -163,10 +167,11 @@ class ChargePoint:
         except KeyError:
             raise NotImplementedError(f"No handler for '{msg.action}' "
                                       "registered.")
-
-        if not handlers.get('_skip_schema_validation', False):
-            validate_payload(msg, self._ocpp_version)
-
+        try:
+            if not handlers.get('_skip_schema_validation', False):
+                validate_payload(msg, self._ocpp_version)
+        except Exception as e:
+            LOGGER.exception(e)
         # OCPP uses camelCase for the keys in the payload. It's more pythonic
         # to use snake_case for keyword arguments. Therefore the keys must be
         # 'translated'. Some examples:

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -167,11 +167,10 @@ class ChargePoint:
         except KeyError:
             raise NotImplementedError(f"No handler for '{msg.action}' "
                                       "registered.")
-        try:
-            if not handlers.get('_skip_schema_validation', False):
-                validate_payload(msg, self._ocpp_version)
-        except Exception as e:
-            LOGGER.exception(e)
+
+        if not handlers.get('_skip_schema_validation', False):
+            validate_payload(msg, self._ocpp_version)
+
         # OCPP uses camelCase for the keys in the payload. It's more pythonic
         # to use snake_case for keyword arguments. Therefore the keys must be
         # 'translated'. Some examples:

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -123,11 +123,7 @@ class ChargePoint:
             message = await self._connection.recv()
             LOGGER.info('%s: receive message %s', self.id, message)
 
-            try:
-                await self.route_message(message)
-            except Exception as e:
-                LOGGER.exception(e)
-
+            await self.route_message(message)            
 
     async def route_message(self, raw_msg):
         """

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -123,7 +123,7 @@ class ChargePoint:
             message = await self._connection.recv()
             LOGGER.info('%s: receive message %s', self.id, message)
 
-            await self.route_message(message)            
+            await self.route_message(message)
 
     async def route_message(self, raw_msg):
         """


### PR DESCRIPTION
I don't know if it is better to handle this in the loop or outside the loop but currently I have the behavior that Schema violations are not logged.

This was seen using the html file from https://github.com/JavaIsJavaScript/OCPP-2.0-CP-Simulator.
In this project the modem iccid contains more than 20 chars like this:  "iccid": "MMCC IINN NNNN NNNN NN C x",

Using the proposed fix the Logger gives feedback to the user. Otherwise the connection is closed without a reason and the websocket connection returns with 1011