### PR TITLE
tests: fix validation of date-time format fields

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -184,7 +184,8 @@ def get_validator(
     #     Unexpected UTF-8 BOM (decode using utf-8-sig):
     with open(path, 'r', encoding='utf-8-sig') as f:
         data = f.read()
-        validator = Draft4Validator(json.loads(data, parse_float=parse_float), format_checker=FormatChecker())
+        validator = Draft4Validator(json.loads(data, parse_float=parse_float),
+                                    format_checker=FormatChecker())
         _validators[cache_key] = validator
 
     return _validators[cache_key]

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Callable, Dict
 from dataclasses import asdict, is_dataclass
 
-from jsonschema import Draft4Validator
+from jsonschema import Draft4Validator, FormatChecker
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 
 from ocpp.exceptions import (OCPPError, FormatViolationError,
@@ -184,7 +184,7 @@ def get_validator(
     #     Unexpected UTF-8 BOM (decode using utf-8-sig):
     with open(path, 'r', encoding='utf-8-sig') as f:
         data = f.read()
-        validator = Draft4Validator(json.loads(data, parse_float=parse_float))
+        validator = Draft4Validator(json.loads(data, parse_float=parse_float), format_checker=FormatChecker())
         _validators[cache_key] = validator
 
     return _validators[cache_key]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -156,7 +156,7 @@ def test_validate_payload_with_valid_payload(ocpp_version):
     message = CallResult(
         unique_id="1234",
         action="Heartbeat",
-        payload={'currentTime': datetime.now().isoformat()}
+        payload={'currentTime': datetime.now().isoformat()+'Z'}
     )
 
     validate_payload(message, ocpp_version=ocpp_version)

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -24,7 +24,7 @@ async def test_route_message_with_existing_route(base_central_system,
         assert kwargs['firmware_version'] == "#1:3.4.0-2990#N:217H;1.0-223"
 
         return call_result.BootNotificationPayload(
-            current_time='2018-05-29T17:37:05.495259',
+            current_time='2018-05-29T17:37:05.495259Z',
             interval=350,
             status='Accepted',
         )
@@ -46,7 +46,7 @@ async def test_route_message_with_existing_route(base_central_system,
             3,
             "1",
             {
-                'currentTime': '2018-05-29T17:37:05.495259',
+                'currentTime': '2018-05-29T17:37:05.495259Z',
                 'interval': 350,
                 'status': 'Accepted',
             }
@@ -63,7 +63,7 @@ async def test_route_message_without_validation(base_central_system):
         assert kwargs['firmware_version'] == "#1:3.4.0-2990#N:217H;1.0-223"
 
         return call_result.BootNotificationPayload(
-            current_time='2018-05-29T17:37:05.495259',
+            current_time='2018-05-29T17:37:05.495259Z',
             interval=350,
             # 'Yolo' is not a valid value for for field status.
             status='Yolo',
@@ -90,7 +90,7 @@ async def test_route_message_without_validation(base_central_system):
             3,
             "1",
             {
-                'currentTime': '2018-05-29T17:37:05.495259',
+                'currentTime': '2018-05-29T17:37:05.495259Z',
                 'interval': 350,
                 'status': 'Yolo',
             }

--- a/tests/v20/test_v20_charge_point.py
+++ b/tests/v20/test_v20_charge_point.py
@@ -23,7 +23,7 @@ async def test_route_message_with_existing_route(base_central_system,
         }
 
         return call_result.BootNotificationPayload(
-            current_time='2018-05-29T17:37:05.495259',
+            current_time='2018-05-29T17:37:05.495259Z',
             interval=350,
             status='Accepted',
         )
@@ -48,7 +48,7 @@ async def test_route_message_with_existing_route(base_central_system,
             3,
             "1",
             {
-                'currentTime': '2018-05-29T17:37:05.495259',
+                'currentTime': '2018-05-29T17:37:05.495259Z',
                 'interval': 350,
                 'status': 'Accepted',
             }

--- a/tests/v201/test_v201_charge_point.py
+++ b/tests/v201/test_v201_charge_point.py
@@ -23,7 +23,7 @@ async def test_route_message_with_existing_route(base_central_system,
         }
 
         return call_result.BootNotificationPayload(
-            current_time='2018-05-29T17:37:05.495259',
+            current_time='2018-05-29T17:37:05.495259Z',
             interval=350,
             status='Accepted',
         )
@@ -48,7 +48,7 @@ async def test_route_message_with_existing_route(base_central_system,
             3,
             "1",
             {
-                'currentTime': '2018-05-29T17:37:05.495259',
+                'currentTime': '2018-05-29T17:37:05.495259Z',
                 'interval': 350,
                 'status': 'Accepted',
             }


### PR DESCRIPTION
In JSON format_checker=FormatChecker() should be
explicitly passed so the format of the field is
checked as it is None by default.

class jsonschema.Draft4Validator(schema, types=(),
resolver=None, format_checker=None)

For more info:
https://python-jsonschema.readthedocs.io/en/stable/validate/