### PR TITLE
fix: limit array in meterValue and sampledValue

### DIFF
--- a/ocpp/v16/schemas/MeterValues.json
+++ b/ocpp/v16/schemas/MeterValues.json
@@ -11,6 +11,7 @@
         },
         "meterValue": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "type": "object",
                 "properties": {
@@ -20,6 +21,7 @@
                     },
                     "sampledValue": {
                         "type": "array",
+                        "minItems": 1,
                         "items": {
                             "type": "object",
                             "properties": {


### PR DESCRIPTION
**Context:**
From OCPP 1.6, section 7.33:

>MeterValue
>Class
>Collection of one or more sampled values in MeterValues.req. All sampled values in a MeterValue are
>sampled at the same point in time.

>sampledValue
>Required. One or more measured values

**Problem**:
The v16/schemas/MeterValues.json accepts the following:

Empty list of meterValue

```
{
  "connectorId": 22883461,
  "meterValue": [],
  "transactionId": -15150072
}
```
Empty list of sampledValue

```
{

  "connectorId": 22883461,
  "meterValue": [{
      "timestamp": "2020-08-19T05:35:53.953Z",
      "sampledValue": []
    },],
  "transactionId": -15150072
}
```
**Proposal**:

I suggest to limit the length of the arrays by the use of the
minItems to 1 in both sampledValue and meterValue. Check documentation
https://json-schema.org/understanding-json-schema/reference/array.html#length