### PR TITLE
fix: use DataTransferStatus in status

### DIFF
--- a/ocpp/v16/call_result.py
+++ b/ocpp/v16/call_result.py
@@ -8,6 +8,7 @@ from ocpp.v16.enums import (
     ClearCacheStatus,
     ClearChargingProfileStatus,
     ConfigurationStatus,
+    DataTransferStatus,
     GetCompositeScheduleStatus,
     RegistrationStatus,
     RemoteStartStopStatus,
@@ -188,5 +189,5 @@ class UpdateFirmwarePayload:
 
 @dataclass
 class DataTransferPayload:
-    status: str
+    status: DataTransferStatus
     data: Optional[str] = None


### PR DESCRIPTION
In ocpp 1.6, the field status is of type
DataTransferStatus, as we have it defined,
this is what we should be using for the
status field of DataTransferPayload.