### PR TITLE
Only route messages if connection is not None

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -119,7 +119,7 @@ class ChargePoint:
         self._unique_id_generator = uuid.uuid4
 
     async def start(self):
-        while True:
+        while self._connection is not None:
             message = await self._connection.recv()
             LOGGER.info('%s: receive message %s', self.id, message)
 


### PR DESCRIPTION
We have an edge case when using a ChargePoint instance with Home Assistant (https://github.com/lbbrhzn/ocpp/) where the Charger does not close its websocket properly and keeps sending messages. In the integration we want to keep the ChargePoint instance and simply reconnect the websocket when it fails eg network, reboot etc. This can be done by setting the `_connection` to `None` but with the current code `while True` throws an `AttributeError`. Checking the connection is not none would solve this and is preferable to checking the websocket is still open in my view.