### PR TITLE
Remove depreciated get_schema code

### DIFF
--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -79,6 +79,14 @@ def test_get_validator_with_valid_name():
     }
 
 
+def test_get_validator_with_invalid_name():
+    """
+    Test if OSError is raised when schema validation file cannnot be found.
+    """
+    with pytest.raises(OSError):
+        get_validator(MessageType.Call, "non-existing", ocpp_version="1.6")
+
+
 def test_validate_set_charging_profile_payload():
     """" Test if payloads with floats are validated correctly.
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -8,9 +8,9 @@ from ocpp.exceptions import (ValidationError, ProtocolError,
                              FormatViolationError,
                              PropertyConstraintViolationError,
                              UnknownCallErrorCodeError)
-from ocpp.messages import (validate_payload, get_schema, _schemas,
-                           get_validator, _validators, unpack, Call, CallError,
-                           CallResult, MessageType, _DecimalEncoder)
+from ocpp.messages import (validate_payload, get_validator, _validators,
+                           unpack, Call, CallError, CallResult, MessageType,
+                           _DecimalEncoder)
 
 
 def test_unpack_with_invalid_json():
@@ -49,34 +49,6 @@ def test_unpack_with_invalid_message_type_id_in_json():
     """
     with pytest.raises(PropertyConstraintViolationError):
         unpack(json.dumps([5, 1]))
-
-
-def test_get_schema_with_valid_name():
-    """
-    Test if correct schema is returned and if schema is added to cache.
-    """
-    schema = get_schema(MessageType.Call, "Reset", ocpp_version="1.6")
-
-    assert schema == _schemas["v16/schemas/Reset.json"]
-    assert schema == {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "title": "ResetRequest",
-        "type": "object",
-        "properties": {
-            "type": {
-                'additionalProperties': False,
-                "type": "string",
-                "enum": [
-                    "Hard",
-                    "Soft"
-                ]
-            }
-        },
-        "additionalProperties": False,
-        "required": [
-            "type"
-        ]
-    }
 
 
 def test_get_validator_with_valid_name():
@@ -166,14 +138,6 @@ def test_validate_get_composite_profile_payload():
         })
 
     validate_payload(message, ocpp_version="1.6")
-
-
-def test_get_schema_with_invalid_name():
-    """
-    Test if OSError is raised when schema validation file cannnot be found.
-    """
-    with pytest.raises(OSError):
-        get_schema(MessageType.Call, "non-existing", ocpp_version="1.6")
 
 
 @pytest.mark.parametrize('ocpp_version', ['1.6', '2.0'])


### PR DESCRIPTION
When running tests I noticed the following warning: `UserWarning: Depricated as of 0.8.1. Please use `ocpp.messages.get_validator()`

As the next revision will be 0.8.4, I figured I would submit a PR to remove this warning.