### PR TITLE
Fix bug in `remove_nones()` when processing `str`

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 import re
 import time
+from typing import Union, List, Dict
 from dataclasses import asdict
 
 from ocpp.routing import create_route_map
@@ -70,19 +71,14 @@ def snake_to_camel_case(data):
     return data
 
 
-def remove_nones(dict_to_scan):
-    new_dict = {}
-    for k, v in dict_to_scan.items():
-        if isinstance(v, dict):
-            v = remove_nones(v)
-        if isinstance(v, list):
-            new_list = []
-            for item in v:
-                new_list.append(remove_nones(item))
-            v = new_list
-        if v is not None:
-            new_dict[k] = v
-    return new_dict
+def remove_nones(data: Union[List, Dict]) -> Union[List, Dict]:
+    if isinstance(data, dict):
+        return {k: remove_nones(v) for k, v in data.items() if v is not None}
+
+    elif isinstance(data, list):
+        return [remove_nones(v) for v in data if v is not None]
+
+    return data
 
 
 class ChargePoint:

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 import pytest
 from ocpp.v20 import ChargePoint as cp
 from ocpp.routing import on, create_route_map
-from ocpp.v16.call import BootNotificationPayload, MeterValuesPayload
+from ocpp.v16.call import BootNotificationPayload, MeterValuesPayload, GetConfigurationPayload
 from ocpp.v16.enums import Action
 from ocpp.v16.datatypes import MeterValue, SampledValue
 from ocpp.v201.call import SetNetworkProfilePayload
@@ -67,7 +67,6 @@ def test_camel_to_snake_case(test_input, expected):
 def test_snake_to_camel_case(test_input, expected):
     result = snake_to_camel_case(test_input)
     assert result == expected
-
 
 def test_remove_nones():
     expected_payload = {'charge_point_model': 'foo',
@@ -148,3 +147,19 @@ def test_nested_list_remove_nones():
 
     payload = asdict(payload)
     assert expected_payload == remove_nones(payload)
+
+
+def test_remove_nones_with_list_of_strings():
+    """ Make sure that `remove_nones()` doesn't crash when it encounters an
+    iterable other than a list or dict. See
+    https://github.com/mobilityhouse/ocpp/issues/289.
+    """
+    payload = asdict(
+        GetConfigurationPayload(
+            key=["ClockAlignedDataInterval", "ConnectionTimeOut"]
+        )
+    )
+
+    assert remove_nones(payload) == {
+        'key': ['ClockAlignedDataInterval', 'ConnectionTimeOut']
+    }

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -3,7 +3,8 @@ from dataclasses import asdict
 import pytest
 from ocpp.v20 import ChargePoint as cp
 from ocpp.routing import on, create_route_map
-from ocpp.v16.call import BootNotificationPayload, MeterValuesPayload, GetConfigurationPayload
+from ocpp.v16.call import (BootNotificationPayload, MeterValuesPayload,
+                           GetConfigurationPayload)
 from ocpp.v16.enums import Action
 from ocpp.v16.datatypes import MeterValue, SampledValue
 from ocpp.v201.call import SetNetworkProfilePayload
@@ -67,6 +68,7 @@ def test_camel_to_snake_case(test_input, expected):
 def test_snake_to_camel_case(test_input, expected):
     result = snake_to_camel_case(test_input)
     assert result == expected
+
 
 def test_remove_nones():
     expected_payload = {'charge_point_model': 'foo',


### PR DESCRIPTION
`remove_nones()` only works with `list`s and `dict`s, not with other
iterables like `str`. However, the function didn't properly checked its
input and would crash when passed a `list` of `str`s.

Fixes: #289