### PR TITLE
Improved error handling during schema validation

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -192,14 +192,14 @@ def validate_payload(message, ocpp_version):
         validator.validate(message.payload)
     except SchemaValidationError as e:
         if (e.validator == SchemaValidators.type.__name__):
-            raise TypeConstraintViolationError(details={"cause":e.message})
+            raise TypeConstraintViolationError(details={"cause": e.message})
         elif (e.validator == SchemaValidators.additionalProperties.__name__):
-            raise FormatViolationError(details={"cause":e.message})
+            raise FormatViolationError(details={"cause": e.message})
         elif (e.validator == SchemaValidators.required.__name__):
-            raise ProtocolError(details={"cause":e.message})
+            raise ProtocolError(details={"cause": e.message})
         else:
             raise ValidationError(f"Payload '{message.payload} for action "
-                              f"'{message.action}' is not valid: {e}")
+                                  f"'{message.action}' is not valid: {e}")
 
 
 class Call:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -7,6 +7,7 @@ from ocpp.v16.enums import Action
 from ocpp.exceptions import (ValidationError, ProtocolError,
                              FormatViolationError,
                              PropertyConstraintViolationError,
+                             TypeConstraintViolationError,
                              UnknownCallErrorCodeError)
 from ocpp.messages import (validate_payload, get_validator, _validators,
                            unpack, Call, CallError, CallResult, MessageType,
@@ -163,10 +164,10 @@ def test_validate_payload_with_valid_payload(ocpp_version):
     validate_payload(message, ocpp_version=ocpp_version)
 
 
-def test_validate_payload_with_invalid_payload():
+def test_validate_payload_with_invalid_additional_properties_payload():
     """
-    Test if validate_payload raises ValidationError when validation of
-    payload failes.
+    Test if validate_payload raises FormatViolationError when validation of
+    payload with unrequested properties fails.
     """
     message = CallResult(
         unique_id="1234",
@@ -174,7 +175,47 @@ def test_validate_payload_with_invalid_payload():
         payload={'invalid_key': True},
     )
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(FormatViolationError):
+        validate_payload(message, ocpp_version="1.6")
+
+
+def test_validate_payload_with_invalid_type_payload():
+    """
+    Test if validate_payload raises TypeConstraintViolationError when
+    validation of payload with mismatched type fails.
+    """
+    message = Call(
+        unique_id="1234",
+        action="StartTransaction",
+        payload={
+            'connectorId': 1,
+            'idTag': "okTag",
+            'meterStart': "invalid_type",
+            'timestamp': '2022-01-25T19:18:30.018Z'
+            },
+    )
+
+    with pytest.raises(TypeConstraintViolationError):
+        validate_payload(message, ocpp_version="1.6")
+
+
+def test_validate_payload_with_invalid_missing_property_payload():
+    """
+    Test if validate_payload raises ProtocolError when validation of
+    payload with missing properties fails.
+    """
+    message = Call(
+        unique_id="1234",
+        action="StartTransaction",
+        payload={
+            'connectorId': 1,
+            'idTag': "okTag",
+            # meterStart is purposely missing
+            'timestamp': '2022-01-25T19:18:30.018Z'
+            },
+    )
+
+    with pytest.raises(ProtocolError):
         validate_payload(message, ocpp_version="1.6")
 
 

--- a/tests/v20/test_v20_charge_point.py
+++ b/tests/v20/test_v20_charge_point.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 
-from ocpp.exceptions import NotImplementedError
 from ocpp.routing import on, after, create_route_map
 from ocpp.v20 import call_result
 
@@ -62,12 +61,22 @@ async def test_route_message_with_existing_route(base_central_system,
 async def test_route_message_with_no_route(base_central_system,
                                            heartbeat_call):
     """
-    Test that NotImplementedError is raised when message received without a
-    handler registered for it.
+    Test that a CALLERROR is sent back, reporting that no handler is
+    registred for it.
 
     """
     # Empty the route map
     base_central_system.route_map = {}
 
-    with pytest.raises(NotImplementedError):
-        await base_central_system.route_message(heartbeat_call)
+    await base_central_system.route_message(heartbeat_call)
+    base_central_system._connection.send.assert_called_once_with(
+        json.dumps([
+            4,
+            1,
+            "NotImplemented",
+            "No handler for \'Heartbeat\' registered.",
+            {}
+        ],
+            separators=(',', ':')
+        )
+    )


### PR DESCRIPTION
Added error differentiation when schema is invalid. supporting:
        - <Error in schema> : <Error sent to CP>
        - Type mismatch: TypeConstraintViolationError
        - Lack of properties: ProtocolError
        - Non-requested properties: FormatViolationError

Now catches exceptions thrown by schema validation errors instead of
dropping the WS connection.

Previous behavior was to drop the socket connection whenever a request payload was not compliant with the schema, this PR introduces support for schema error handling according to the OCPP specification (from 1.6 to 2.0.1).