### PR TITLE
Raise maxLength violation as ocpp error

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -197,6 +197,8 @@ def validate_payload(message, ocpp_version):
             raise FormatViolationError(details={"cause": e.message})
         elif (e.validator == SchemaValidators.required.__name__):
             raise ProtocolError(details={"cause": e.message})
+        elif e.validator == "maxLength":
+            raise TypeConstraintViolationError(details={"cause": e.message}) from e
         else:
             raise ValidationError(f"Payload '{message.payload} for action "
                                   f"'{message.action}' is not valid: {e}")

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -198,7 +198,8 @@ def validate_payload(message, ocpp_version):
         elif (e.validator == SchemaValidators.required.__name__):
             raise ProtocolError(details={"cause": e.message})
         elif e.validator == "maxLength":
-            raise TypeConstraintViolationError(details={"cause": e.message}) from e
+            raise TypeConstraintViolationError(
+                details={"cause": e.message}) from e
         else:
             raise ValidationError(f"Payload '{message.payload} for action "
                                   f"'{message.action}' is not valid: {e}")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -328,3 +328,18 @@ def test_validate_meter_values_hertz():
     )
 
     validate_payload(message, ocpp_version="1.6")
+
+
+def test_validate_set_maxlength_violation_payload():
+    """Test if payloads that violate maxLength raise a TypeConstraintViolationError"""
+    message = Call(
+        unique_id="1234",
+        action="StartTransaction",
+        payload={
+            "idTag": "012345678901234567890",
+            "connectorId": 1,
+        },
+    )
+
+    with pytest.raises(TypeConstraintViolationError):
+        validate_payload(message, ocpp_version="1.6")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -331,7 +331,10 @@ def test_validate_meter_values_hertz():
 
 
 def test_validate_set_maxlength_violation_payload():
-    """Test if payloads that violate maxLength raise a TypeConstraintViolationError"""
+    """
+    Test if payloads that violate maxLength raise a
+    TypeConstraintViolationError
+    """
     message = Call(
         unique_id="1234",
         action="StartTransaction",


### PR DESCRIPTION
According to ocpp-j-1.6-specification , section "4.2.3 CallError", a unique identifier that is too long is a reason for a call error of type TypeConstraintViolationError