### PR TITLE
Respond to calls with call error

### DIFF
--- a/ocpp/exceptions.py
+++ b/ocpp/exceptions.py
@@ -31,14 +31,14 @@ class OCPPError(Exception):
 
 class NotImplementedError(OCPPError):
     code = "NotImplemented"
-    default_description = "Request Action is recognized but not supported by \
-                          the receiver"
+    default_description = ("Request Action is recognized but not supported by "
+                           "the receiver")
 
 
 class InternalError(OCPPError):
     code = "InternalError"
-    default_description = "An internal error occurred and the receiver was \
-                          able to process the requested Action successfully"
+    default_description = ("An internal error occurred and the receiver was "
+                           "able to process the requested Action successfully")
 
 
 class ProtocolError(OCPPError):
@@ -48,35 +48,35 @@ class ProtocolError(OCPPError):
 
 class SecurityError(OCPPError):
     code = "SecurityError"
-    default_description = "During the processing of Action a security issue \
-                          occurred preventing receiver from completing the \
-                          Action successfully"
+    default_description = ("During the processing of Action a security issue "
+                           "occurred preventing receiver from completing the "
+                           "Action successfully")
 
 
 class FormatViolationError(OCPPError):
     code = "FormatViolation"
-    default_description = "Payload for Action is syntactically incorrect or \
-                          structure for Action"
+    default_description = ("Payload for Action is syntactically incorrect or "
+                           "structure for Action")
 
 
 class PropertyConstraintViolationError(OCPPError):
     code = "PropertyConstraintViolation"
-    default_description = "Payload is syntactically correct but at least \
-                          one field contains an invalid value"
+    default_description = ("Payload is syntactically correct but at least "
+                           "one field contains an invalid value")
 
 
 class OccurenceConstraintViolationError(OCPPError):
     code = "OccurenceConstraintViolation"
-    default_description = "Payload for Action is syntactically correct but \
-                          at least one of the fields violates occurence \
-                          constraints"
+    default_description = ("Payload for Action is syntactically correct but "
+                           "at least one of the fields violates occurence "
+                           "constraints")
 
 
 class TypeConstraintViolationError(OCPPError):
     code = "TypeConstraintViolation"
-    default_description = "Payload for Action is syntactically correct but at \
-                          least one of the fields violates data type \
-                          constraints (e.g. “somestring”: 12)"
+    default_description = ("Payload for Action is syntactically correct but "
+                           "at least one of the fields violates data type "
+                           "constraints (e.g. “somestring”: 12)")
 
 
 class GenericError(OCPPError):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -287,3 +287,11 @@ def test_validate_meter_values_hertz():
     )
 
     validate_payload(message, ocpp_version="1.6")
+
+
+def test_create_call_error_from_call():
+    call = Call(unique_id="1", action=Action.Heartbeat, payload={})
+    call_error = call.create_call_error(FormatViolationError()).to_json()
+    assert call_error == ('[4,"1","FormatViolation","Payload for Action is '
+                          'syntactically incorrect or structure for '
+                          'Action",{}]')

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -3,7 +3,7 @@ import pytest
 import asyncio
 from unittest import mock
 
-from ocpp.exceptions import NotImplementedError, ValidationError, GenericError
+from ocpp.exceptions import ValidationError, GenericError
 from ocpp.messages import CallError
 from ocpp.routing import on, after, create_route_map
 from ocpp.v16.enums import Action
@@ -110,8 +110,11 @@ async def test_route_message_with_no_route(base_central_system,
     # Empty the route map
     base_central_system.route_map = {}
 
-    with pytest.raises(NotImplementedError):
-        await base_central_system.route_message(heartbeat_call)
+    await base_central_system.route_message(heartbeat_call)
+
+    base_central_system._connection.send.assert_called_with(
+        ('[4,1,"NotImplemented","Request Action is recognized '
+         'but not supported by the receiver",{}]'))
 
 
 @pytest.mark.asyncio

--- a/tests/v20/test_v20_charge_point.py
+++ b/tests/v20/test_v20_charge_point.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 
-from ocpp.exceptions import NotImplementedError
 from ocpp.routing import on, after, create_route_map
 from ocpp.v20 import call_result
 
@@ -69,5 +68,8 @@ async def test_route_message_with_no_route(base_central_system,
     # Empty the route map
     base_central_system.route_map = {}
 
-    with pytest.raises(NotImplementedError):
-        await base_central_system.route_message(heartbeat_call)
+    await base_central_system.route_message(heartbeat_call)
+
+    base_central_system._connection.send.assert_called_with(
+        ('[4,1,"NotImplemented","Request Action is recognized '
+         'but not supported by the receiver",{}]'))

--- a/tests/v201/test_v201_charge_point.py
+++ b/tests/v201/test_v201_charge_point.py
@@ -1,7 +1,6 @@
 import json
 import pytest
 
-from ocpp.exceptions import NotImplementedError
 from ocpp.routing import on, after, create_route_map
 from ocpp.v201 import call_result
 
@@ -69,5 +68,8 @@ async def test_route_message_with_no_route(base_central_system,
     # Empty the route map
     base_central_system.route_map = {}
 
-    with pytest.raises(NotImplementedError):
-        await base_central_system.route_message(heartbeat_call)
+    await base_central_system.route_message(heartbeat_call)
+
+    base_central_system._connection.send.assert_called_with(
+        ('[4,1,"NotImplemented","Request Action is recognized '
+         'but not supported by the receiver",{}]'))


### PR DESCRIPTION
Part 4 of the 2.0.1 spec, pp. 13-14,  indicates that if the message does not meet the requirements of a proper message, a CallError should be returned. This PR adds handling of some exceptions (Formatting issues, not implemented messages, and generic errors) to return a corresponding CallError.