### PR TITLE
Make CI use latest bugfix release of Python 3.10

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [3.7, 3.8, 3.9, 3.10.0]
+        version:
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.version }}


### PR DESCRIPTION
Pinning to `3.10.0` was probably done to avoid using `3.10`, which is a YAML float with vlaue `3.1`. Instead of doing that, use a string specifier, which installs the latest bugfix release of Python 3.10 (currently 3.10.7). This will stop any possible encounters with already-fixed bugs in Python.