### PR TITLE
Run tests before deploying

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Setup the Python Environment by installing Poetry
       uses: ./.github/actions/setup-python-build-env
 
+    - name: Code Quality Check
+      shell: bash
+      run: make install && make tests
+
     - name: Poetry bump version, build and publish
       shell: bash
       run: |


### PR DESCRIPTION
The unit tests aren't ran before release.
This commit fixes this to avoid releasing without
running the tests.

Fixes: https://github.com/mobilityhouse/ocpp/issues/337