### PR TITLE
[DVI-509] OCPP Validation logging

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -98,7 +98,8 @@ def unpack(msg):
                 details={"cause": "Message does not contain MessageTypeId"}
             )
         except TypeError:
-            raise ProtocolError(details={"cause": "Message is missing elements."})
+            raise ProtocolError(details={"cause": "Message is missing"
+                                                  " elements."})
 
     raise PropertyConstraintViolationError(
         details={"cause": f"MessageTypeId '{msg[0]}' isn't valid"}
@@ -116,7 +117,10 @@ def pack(msg):
 
 
 def get_validator(
-    message_type_id: int, action: str, ocpp_version: str, parse_float: Callable = float
+        message_type_id: int,
+        action: str,
+        ocpp_version: str,
+        parse_float: Callable = float
 ) -> Draft4Validator:
     """
     Read schema from disk and return as `Draft4Validator`. Instances will be
@@ -318,7 +322,10 @@ class CallError:
 
     message_type_id = 4
 
-    def __init__(self, unique_id, error_code, error_description, error_details=None):
+    def __init__(self, unique_id,
+                 error_code,
+                 error_description,
+                 error_details=None):
         self.unique_id = unique_id
         self.error_code = error_code
         self.error_description = error_description
@@ -344,7 +351,8 @@ class CallError:
         for error in OCPPError.__subclasses__():
             if error.code == self.error_code:
                 return error(
-                    description=self.error_description, details=self.error_details
+                    description=self.error_description,
+                    details=self.error_details
                 )
 
         raise UnknownCallErrorCodeError(
@@ -361,7 +369,8 @@ class CallError:
         )
 
 
-def validate_payload(message: Union[Call, CallResult], ocpp_version: str) -> None:
+def validate_payload(message: Union[Call, CallResult],
+                     ocpp_version: str) -> None:
     """Validate the payload of the message using JSON schemas."""
     if type(message) not in [Call, CallResult]:
         raise ValidationError(
@@ -389,7 +398,8 @@ def validate_payload(message: Union[Call, CallResult], ocpp_version: str) -> Non
         if ocpp_version == "1.6" and (
             (
                 isinstance(message, Call)
-                and message.action in ["SetChargingProfile", "RemoteStartTransaction"]
+                and message.action in ["SetChargingProfile",
+                                       "RemoteStartTransaction"]
             )  # noqa
             or (
                 isinstance(message, CallResult)

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -1,5 +1,7 @@
 """ Module containing classes that model the several OCPP messages types. It
 also contain some helper functions for packing and unpacking messages.  """
+from __future__ import annotations
+
 import decimal
 import json
 import os
@@ -160,6 +162,86 @@ def get_validator(
         _validators[cache_key] = validator
 
     return _validators[cache_key]
+
+
+def validate_payload(message: Union[Call, CallResult], ocpp_version: str) -> None:
+    """Validate the payload of the message using JSON schemas."""
+    if type(message) not in [Call, CallResult]:
+        raise ValidationError(
+            "Payload can't be validated because message "
+            f"type. It's '{type(message)}', but it should "
+            "be either 'Call'  or 'CallResult'."
+        )
+
+    try:
+        # 3 OCPP 1.6 schedules have fields of type floats. The JSON schema
+        # defines a certain precision for these fields of 1 decimal. A value of
+        # 21.4 is valid, whereas a value if 4.11 is not.
+        #
+        # The problem is that Python's internal representation of 21.4 might
+        # have more than 1 decimal. It might be 21.399999999999995. This would
+        # make the validation fail, although the payload is correct. This is a
+        # known issue with jsonschemas, see:
+        # https://github.com/Julian/jsonschema/issues/247
+        #
+        # This issue can be fixed by using a different parser for floats than
+        # the default one that is used.
+        #
+        # Both the schema and the payload must be parsed using the different
+        # parser for floats.
+        if ocpp_version == "1.6" and (
+            (
+                type(message) == Call
+                and message.action in ["SetChargingProfile", "RemoteStartTransaction"]
+            )  # noqa
+            or (
+                type(message) == CallResult and message.action == "GetCompositeSchedule"
+            )
+        ):
+            validator = get_validator(
+                message.message_type_id,
+                message.action,
+                ocpp_version,
+                parse_float=decimal.Decimal,
+            )
+
+            message.payload = json.loads(
+                json.dumps(message.payload), parse_float=decimal.Decimal
+            )
+        else:
+            validator = get_validator(
+                message.message_type_id, message.action, ocpp_version
+            )
+    except (OSError, json.JSONDecodeError):
+        raise NotImplementedError(
+            details={"cause": f"Failed to validate action: {message.action}"}
+        )
+
+    try:
+        validator.validate(message.payload)
+    except SchemaValidationError as e:
+        if e.validator == SchemaValidators.type.__name__:
+            raise TypeConstraintViolationError(
+                details={"cause": e.message, "ocpp_message": message}
+            )
+        elif e.validator == SchemaValidators.additionalProperties.__name__:
+            raise FormatViolationError(
+                details={"cause": e.message, "ocpp_message": message}
+            )
+        elif e.validator == SchemaValidators.required.__name__:
+            raise ProtocolError(details={"cause": e.message})
+        elif e.validator == "maxLength":
+            raise TypeConstraintViolationError(
+                details={"cause": e.message, "ocpp_message": message}
+            ) from e
+        else:
+            raise FormatViolationError(
+                details={
+                    "cause": f"Payload '{message.payload} for action "
+                    f"'{message.action}' is not valid: {e}",
+                    "ocpp_message": message,
+                }
+            )
 
 
 class Call:
@@ -360,83 +442,3 @@ class CallError:
             f"error_description={self.error_description}, "
             f"error_details={self.error_details}>"
         )
-
-
-def validate_payload(message: Union[Call, CallResult], ocpp_version: str) -> None:
-    """Validate the payload of the message using JSON schemas."""
-    if type(message) not in [Call, CallResult]:
-        raise ValidationError(
-            "Payload can't be validated because message "
-            f"type. It's '{type(message)}', but it should "
-            "be either 'Call'  or 'CallResult'."
-        )
-
-    try:
-        # 3 OCPP 1.6 schedules have fields of type floats. The JSON schema
-        # defines a certain precision for these fields of 1 decimal. A value of
-        # 21.4 is valid, whereas a value if 4.11 is not.
-        #
-        # The problem is that Python's internal representation of 21.4 might
-        # have more than 1 decimal. It might be 21.399999999999995. This would
-        # make the validation fail, although the payload is correct. This is a
-        # known issue with jsonschemas, see:
-        # https://github.com/Julian/jsonschema/issues/247
-        #
-        # This issue can be fixed by using a different parser for floats than
-        # the default one that is used.
-        #
-        # Both the schema and the payload must be parsed using the different
-        # parser for floats.
-        if ocpp_version == "1.6" and (
-            (
-                type(message) == Call
-                and message.action in ["SetChargingProfile", "RemoteStartTransaction"]
-            )  # noqa
-            or (
-                type(message) == CallResult and message.action == "GetCompositeSchedule"
-            )
-        ):
-            validator = get_validator(
-                message.message_type_id,
-                message.action,
-                ocpp_version,
-                parse_float=decimal.Decimal,
-            )
-
-            message.payload = json.loads(
-                json.dumps(message.payload), parse_float=decimal.Decimal
-            )
-        else:
-            validator = get_validator(
-                message.message_type_id, message.action, ocpp_version
-            )
-    except (OSError, json.JSONDecodeError):
-        raise NotImplementedError(
-            details={"cause": f"Failed to validate action: {message.action}"}
-        )
-
-    try:
-        validator.validate(message.payload)
-    except SchemaValidationError as e:
-        if e.validator == SchemaValidators.type.__name__:
-            raise TypeConstraintViolationError(
-                details={"cause": e.message, "ocpp_message": message}
-            )
-        elif e.validator == SchemaValidators.additionalProperties.__name__:
-            raise FormatViolationError(
-                details={"cause": e.message, "ocpp_message": message}
-            )
-        elif e.validator == SchemaValidators.required.__name__:
-            raise ProtocolError(details={"cause": e.message})
-        elif e.validator == "maxLength":
-            raise TypeConstraintViolationError(
-                details={"cause": e.message, "ocpp_message": message}
-            ) from e
-        else:
-            raise FormatViolationError(
-                details={
-                    "cause": f"Payload '{message.payload} for action "
-                    f"'{message.action}' is not valid: {e}",
-                    "ocpp_message": message,
-                }
-            )

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -9,22 +9,17 @@ from dataclasses import asdict, is_dataclass
 from jsonschema import Draft4Validator, _validators as SchemaValidators
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 
-from ocpp.exceptions import (
-    OCPPError,
-    FormatViolationError,
-    PropertyConstraintViolationError,
-    ProtocolError,
-    TypeConstraintViolationError,
-    NotImplementedError,
-    ValidationError,
-    UnknownCallErrorCodeError,
-)
+from ocpp.exceptions import (OCPPError, FormatViolationError,
+                             PropertyConstraintViolationError,
+                             ProtocolError, TypeConstraintViolationError,
+                             NotImplementedError, ValidationError,
+                             UnknownCallErrorCodeError)
 
 _validators: Dict[str, Draft4Validator] = {}
 
 
 class _DecimalEncoder(json.JSONEncoder):
-    """Encode values of type `decimal.Decimal` using 1 decimal point.
+    """ Encode values of type `decimal.Decimal` using 1 decimal point.
 
     A custom encoder is required because `json.dumps()` cannot encode a value
     of type decimal.Decimal. This raises a TypeError:
@@ -47,7 +42,6 @@ class _DecimalEncoder(json.JSONEncoder):
     This can be prevented by using a custom encoder.
 
     """
-
     def default(self, obj):
         if isinstance(obj, decimal.Decimal):
             return float("%.1f" % obj)
@@ -55,8 +49,7 @@ class _DecimalEncoder(json.JSONEncoder):
 
 
 class MessageType:
-    """Number identifying the different types of OCPP messages."""
-
+    """ Number identifying the different types of OCPP messages. """
     #: Call identifies a request.
     Call = 2
 
@@ -75,19 +68,14 @@ def unpack(msg):
         msg = json.loads(msg)
     except json.JSONDecodeError:
         raise FormatViolationError(
-            details={"cause": "Message is not valid JSON", "ocpp_message": msg}
-        )
+            details={"cause": "Message is not valid JSON",
+                     "ocpp_message": msg})
 
     if not isinstance(msg, list):
         raise ProtocolError(
-            details={
-                "cause": (
-                    "OCPP message hasn't the correct format. It "
-                    f"should be a list, but got '{type(msg)}' "
-                    "instead"
-                )
-            }
-        )
+            details={"cause": ("OCPP message hasn't the correct format. It "
+                               f"should be a list, but got '{type(msg)}' "
+                               "instead")})
 
     for cls in [Call, CallResult, CallError]:
         try:
@@ -95,15 +83,13 @@ def unpack(msg):
                 return cls(*msg[1:])
         except IndexError:
             raise ProtocolError(
-                details={"cause": "Message does not contain MessageTypeId"}
-            )
+                details={"cause": "Message does not contain MessageTypeId"})
         except TypeError:
-            raise ProtocolError(details={"cause": "Message is missing"
-                                                  " elements."})
+            raise ProtocolError(
+                details={"cause": "Message is missing elements."})
 
     raise PropertyConstraintViolationError(
-        details={"cause": f"MessageTypeId '{msg[0]}' isn't valid"}
-    )
+        details={"cause": f"MessageTypeId '{msg[0]}' isn't valid"})
 
 
 def pack(msg):
@@ -133,31 +119,31 @@ def get_validator(
     if ocpp_version not in ["1.6", "2.0", "2.0.1"]:
         raise ValueError
 
-    schemas_dir = "v" + ocpp_version.replace(".", "")
+    schemas_dir = 'v' + ocpp_version.replace('.', '')
 
     schema_name = action
     if message_type_id == MessageType.CallResult:
-        schema_name += "Response"
+        schema_name += 'Response'
     elif message_type_id == MessageType.Call:
         if ocpp_version in ["2.0", "2.0.1"]:
-            schema_name += "Request"
+            schema_name += 'Request'
 
     if ocpp_version == "2.0":
-        schema_name += "_v1p0"
+        schema_name += '_v1p0'
 
-    cache_key = schema_name + "_" + ocpp_version
+    cache_key = schema_name + '_' + ocpp_version
     if cache_key in _validators:
         return _validators[cache_key]
 
-    dir, _ = os.path.split(os.path.realpath(__file__))
-    relative_path = f"{schemas_dir}/schemas/{schema_name}.json"
+    dir,  _ = os.path.split(os.path.realpath(__file__))
+    relative_path = f'{schemas_dir}/schemas/{schema_name}.json'
     path = os.path.join(dir, relative_path)
 
     # The JSON schemas for OCPP 2.0 start with a byte order mark (BOM)
     # character. If no encoding is given, reading the schema would fail with:
     #
     #     Unexpected UTF-8 BOM (decode using utf-8-sig):
-    with open(path, "r", encoding="utf-8-sig") as f:
+    with open(path, 'r', encoding='utf-8-sig') as f:
         data = f.read()
         validator = Draft4Validator(json.loads(data, parse_float=parse_float))
         _validators[cache_key] = validator
@@ -166,7 +152,7 @@ def get_validator(
 
 
 class Call:
-    """A Call is a type of message that initiate a request/response sequence.
+    """ A Call is a type of message that initiate a request/response sequence.
     Both central systems and charge points can send this message.
 
     From the specification:
@@ -191,7 +177,6 @@ class Call:
              }
             ]
     """
-
     message_type_id = 2
 
     def __init__(self, unique_id, action, payload):
@@ -203,18 +188,17 @@ class Call:
             self.payload = asdict(payload)
 
     def to_json(self):
-        """Return a valid JSON representation of the instance."""
-        return json.dumps(
-            [
-                self.message_type_id,
-                self.unique_id,
-                self.action,
-                self.payload,
-            ],
+        """ Return a valid JSON representation of the instance. """
+        return json.dumps([
+            self.message_type_id,
+            self.unique_id,
+            self.action,
+            self.payload,
+        ],
             # By default json.dumps() adds a white space after every separator.
             # By setting the separator manually that can be avoided.
-            separators=(",", ":"),
-            cls=_DecimalEncoder,
+            separators=(',', ':'),
+            cls=_DecimalEncoder
         )
 
     def create_call_result(self, payload):
@@ -240,10 +224,8 @@ class Call:
         )
 
     def __repr__(self):
-        return (
-            f"<Call - unique_id={self.unique_id}, action={self.action}, "
-            f"payload={self.payload}>"
-        )
+        return f"<Call - unique_id={self.unique_id}, action={self.action}, " \
+               f"payload={self.payload}>"
 
 
 class CallResult:
@@ -273,7 +255,6 @@ class CallResult:
             ]
 
     """
-
     message_type_id = 3
 
     def __init__(self, unique_id, payload, action=None):
@@ -285,24 +266,21 @@ class CallResult:
         self.action = action
 
     def to_json(self):
-        return json.dumps(
-            [
-                self.message_type_id,
-                self.unique_id,
-                self.payload,
-            ],
+        return json.dumps([
+            self.message_type_id,
+            self.unique_id,
+            self.payload,
+        ],
             # By default json.dumps() adds a white space after every separator.
             # By setting the separator manually that can be avoided.
-            separators=(",", ":"),
-            cls=_DecimalEncoder,
+            separators=(',', ':'),
+            cls=_DecimalEncoder
         )
 
     def __repr__(self):
-        return (
-            f"<CallResult - unique_id={self.unique_id}, "
-            f"action={self.action}, "
-            f"payload={self.payload}>"
-        )
+        return f"<CallResult - unique_id={self.unique_id}, " \
+               f"action={self.action}, " \
+               f"payload={self.payload}>"
 
 
 class CallError:
@@ -319,12 +297,9 @@ class CallError:
 
             [<MessageTypeId>, "<UniqueId>", "<errorCode>", "<errorDescription>", {<errorDetails>}] # noqa
     """
-
     message_type_id = 4
 
-    def __init__(self, unique_id,
-                 error_code,
-                 error_description,
+    def __init__(self, unique_id, error_code, error_description,
                  error_details=None):
         self.unique_id = unique_id
         self.error_code = error_code
@@ -332,22 +307,21 @@ class CallError:
         self.error_details = error_details
 
     def to_json(self):
-        return json.dumps(
-            [
-                self.message_type_id,
-                self.unique_id,
-                self.error_code,
-                self.error_description,
-                self.error_details,
-            ],
+        return json.dumps([
+            self.message_type_id,
+            self.unique_id,
+            self.error_code,
+            self.error_description,
+            self.error_details,
+        ],
             # By default json.dumps() adds a white space after every separator.
             # By setting the separator manually that can be avoided.
-            separators=(",", ":"),
-            cls=_DecimalEncoder,
+            separators=(',', ':'),
+            cls=_DecimalEncoder
         )
 
     def to_exception(self):
-        """Return the exception that corresponds to the CallError."""
+        """ Return the exception that corresponds to the CallError. """
         for error in OCPPError.__subclasses__():
             if error.code == self.error_code:
                 return error(
@@ -355,29 +329,22 @@ class CallError:
                     details=self.error_details
                 )
 
-        raise UnknownCallErrorCodeError(
-            "Error code '%s' is not defined by the OCPP specification",
-            self.error_code,
-        )
+        raise UnknownCallErrorCodeError("Error code '%s' is not defined by the"
+                                        " OCPP specification", self.error_code)
 
     def __repr__(self):
-        return (
-            f"<CallError - unique_id={self.unique_id}, "
-            f"error_code={self.error_code}, "
-            f"error_description={self.error_description}, "
-            f"error_details={self.error_details}>"
-        )
+        return f"<CallError - unique_id={self.unique_id}, " \
+               f"error_code={self.error_code}, " \
+               f"error_description={self.error_description}, " \
+               f"error_details={self.error_details}>"
 
 
-def validate_payload(message: Union[Call, CallResult],
-                     ocpp_version: str) -> None:
-    """Validate the payload of the message using JSON schemas."""
+def validate_payload(message: Union[Call, CallResult], ocpp_version: str) -> None:
+    """ Validate the payload of the message using JSON schemas. """
     if type(message) not in [Call, CallResult]:
-        raise ValidationError(
-            "Payload can't be validated because message "
-            f"type. It's '{type(message)}', but it should "
-            "be either 'Call'  or 'CallResult'."
-        )
+        raise ValidationError("Payload can't be validated because message "
+                              f"type. It's '{type(message)}', but it should "
+                              "be either 'Call'  or 'CallResult'.")
 
     try:
         # 3 OCPP 1.6 schedules have fields of type floats. The JSON schema
@@ -395,22 +362,16 @@ def validate_payload(message: Union[Call, CallResult],
         #
         # Both the schema and the payload must be parsed using the different
         # parser for floats.
-        if ocpp_version == "1.6" and (
-            (
-                isinstance(message, Call)
-                and message.action in ["SetChargingProfile",
-                                       "RemoteStartTransaction"]
-            )  # noqa
-            or (
-                isinstance(message, CallResult)
-                and message.action == "GetCompositeSchedule"
-            )
+        if ocpp_version == '1.6' and (
+            (type(message) == Call and
+                message.action in ['SetChargingProfile', 'RemoteStartTransaction'])  # noqa
+            or
+            (type(message) == CallResult and
+                message.action == 'GetCompositeSchedule')
         ):
             validator = get_validator(
-                message.message_type_id,
-                message.action,
-                ocpp_version,
-                parse_float=decimal.Decimal,
+                message.message_type_id, message.action,
+                ocpp_version, parse_float=decimal.Decimal
             )
 
             message.payload = json.loads(
@@ -422,31 +383,22 @@ def validate_payload(message: Union[Call, CallResult],
             )
     except (OSError, json.JSONDecodeError):
         raise NotImplementedError(
-            details={"cause": f"Failed to validate action: {message.action}"}
-        )
+            details={"cause": f"Failed to validate action: {message.action}"})
 
     try:
         validator.validate(message.payload)
-    except SchemaValidationError as error:
-        if error.validator == SchemaValidators.type.__name__:
+    except SchemaValidationError as e:
+        if e.validator == SchemaValidators.type.__name__:
+            raise TypeConstraintViolationError(details={"cause": e.message, "ocpp_message": message})
+        elif e.validator == SchemaValidators.additionalProperties.__name__:
+            raise FormatViolationError(details={"cause": e.message, "ocpp_message": message})
+        elif e.validator == SchemaValidators.required.__name__:
+            raise ProtocolError(details={"cause": e.message})
+        elif e.validator == "maxLength":
             raise TypeConstraintViolationError(
-                details={"cause": error.message, "ocpp_message": message}
-            )
-        if error.validator == SchemaValidators.additionalProperties.__name__:
+                details={"cause": e.message, "ocpp_message": message}) from e
+        else:
             raise FormatViolationError(
-                details={"cause": error.message, "ocpp_message": message}
-            )
-        if error.validator == SchemaValidators.required.__name__:
-            raise ProtocolError(details={"cause": error.message})
-        if error.validator == "maxLength":
-            raise TypeConstraintViolationError(
-                details={"cause": error.message, "ocpp_message": message}
-            ) from error
-
-        raise FormatViolationError(
-            details={
-                "cause": f"Payload '{message.payload} for action "
-                f"'{message.action}' is not valid: {error}",
-                "ocpp_message": message,
-            }
-        )
+                details={"cause": f"Payload '{message.payload} for action "
+                         f"'{message.action}' is not valid: {e}",
+                         "ocpp_message": message})

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -75,8 +75,7 @@ def unpack(msg):
         raise ProtocolError(
             details={"cause": ("OCPP message hasn't the correct format. It "
                                f"should be a list, but got '{type(msg)}' "
-                               "instead"),
-                     "ocpp_message": msg})
+                               "instead")})
 
     for cls in [Call, CallResult, CallError]:
         try:
@@ -84,12 +83,10 @@ def unpack(msg):
                 return cls(*msg[1:])
         except IndexError:
             raise ProtocolError(
-                details={"cause": "Message does not contain MessageTypeId",
-                         "ocpp_message": msg})
+                details={"cause": "Message does not contain MessageTypeId"})
         except TypeError:
             raise ProtocolError(
-                details={"cause": "Message is missing elements.",
-                         "ocpp_message": msg})
+                details={"cause": "Message is missing elements."})
 
     raise PropertyConstraintViolationError(
         details={"cause": f"MessageTypeId '{msg[0]}' isn't valid"})
@@ -208,7 +205,7 @@ def validate_payload(message, ocpp_version):
         elif e.validator == SchemaValidators.additionalProperties.__name__:
             raise FormatViolationError(details={"cause": e.message, "ocpp_message": message})
         elif e.validator == SchemaValidators.required.__name__:
-            raise ProtocolError(details={"cause": e.message, "ocpp_message": message})
+            raise ProtocolError(details={"cause": e.message})
         elif e.validator == "maxLength":
             raise TypeConstraintViolationError(
                 details={"cause": e.message, "ocpp_message": message}) from e

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,18 +1,14 @@
 import pytest
 
-from ocpp.exceptions import (
-    ProtocolError,
-    TypeConstraintViolationError,
-    FormatViolationError,
-)
+from ocpp.exceptions import ProtocolError, TypeConstraintViolationError, FormatViolationError
 from ocpp.messages import validate_payload, Call
 
 
 def test_exception_with_error_details():
-    exception = ProtocolError("Some error", {"key": "value"})
+    exception = ProtocolError("Some error", {'key': 'value'})
 
     assert exception.description == "Some error"
-    assert exception.details == {"key": "value"}
+    assert exception.details == {'key': 'value'}
 
 
 def test_exception_without_error_details():
@@ -23,40 +19,26 @@ def test_exception_without_error_details():
 
 
 def test_exception_show_triggered_message_type_constraint():
-    """chargePointVendor should be a string, not an integer, so this should
-    raise a TypeConstraintViolationError
-    """
-    call = Call(
-        unique_id=123456,
-        action="BootNotification",
-        payload={"chargePointVendor": 1,
-                 "chargePointModel": "SingleSocketCharger"},
-    )
+    # chargePointVendor should be a string, not an integer, so this should raise a TypeConstraintViolationError
+    call = Call(unique_id=123456,
+                action="BootNotification",
+                payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"})
 
-    regex_pattern = (
-        r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, "
-        r"payload={'chargePointVendor': 1, "
-        r"'chargePointModel': 'SingleSocketCharger'}"
-    )
+    regex_pattern = r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, payload={" \
+                    r"'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
 
     with pytest.raises(TypeConstraintViolationError, match=regex_pattern):
         validate_payload(call, "1.6")
 
 
 def test_exception_show_triggered_message_format():
-    """The payload is syntactically incorrect, which should
-    trigger a FormatViolationError"""
+    # The payload is syntactically incorrect, which should trigger a FormatViolationError
+    call = Call(unique_id=123457,
+                action="BootNotification",
+                payload={"syntactically": "incorrect"})
 
-    call = Call(
-        unique_id=123457,
-        action="BootNotification",
-        payload={"syntactically": "incorrect"},
-    )
-
-    regex_pattern = (
-        r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, "
-        r"payload={'syntactically': 'incorrect'}"
-    )
+    regex_pattern = r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, payload={" \
+                    r"'syntactically': 'incorrect'}"
 
     with pytest.raises(FormatViolationError, match=regex_pattern):
         validate_payload(call, "1.6")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -29,12 +29,14 @@ def test_exception_show_triggered_message_type_constraint():
     call = Call(
         unique_id=123456,
         action="BootNotification",
-        payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"},
+        payload={"chargePointVendor": 1,
+                 "chargePointModel": "SingleSocketCharger"},
     )
 
     regex_pattern = (
-        r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, payload={"
-        r"'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
+        r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, "
+        r"payload={'chargePointVendor': 1, "
+        r"'chargePointModel': 'SingleSocketCharger'}"
     )
 
     with pytest.raises(TypeConstraintViolationError, match=regex_pattern):
@@ -42,7 +44,8 @@ def test_exception_show_triggered_message_type_constraint():
 
 
 def test_exception_show_triggered_message_format():
-    """The payload is syntactically incorrect, which should trigger a FormatViolationError"""
+    """The payload is syntactically incorrect, which should
+    trigger a FormatViolationError"""
 
     call = Call(
         unique_id=123457,
@@ -51,8 +54,8 @@ def test_exception_show_triggered_message_format():
     )
 
     regex_pattern = (
-        r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, payload={"
-        r"'syntactically': 'incorrect'}"
+        r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, "
+        r"payload={'syntactically': 'incorrect'}"
     )
 
     with pytest.raises(FormatViolationError, match=regex_pattern):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,11 @@
 import pytest
 
-from ocpp.exceptions import ProtocolError, TypeConstraintViolationError, FormatViolationError
-from ocpp.messages import validate_payload, Call
+from ocpp.exceptions import (
+    FormatViolationError,
+    ProtocolError,
+    TypeConstraintViolationError,
+)
+from ocpp.messages import Call, validate_payload
 
 
 def test_exception_with_error_details():
@@ -19,26 +23,36 @@ def test_exception_without_error_details():
 
 
 def test_exception_show_triggered_message_type_constraint():
-    # chargePointVendor should be a string, not an integer, so this should raise a TypeConstraintViolationError
-    call = Call(unique_id=123456,
-                action="BootNotification",
-                payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"})
+    # chargePointVendor should be a string, not an integer,
+    # so this should raise a TypeConstraintViolationError
+    call = Call(
+        unique_id=123456,
+        action="BootNotification",
+        payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"},
+    )
+    ocpp_message = (
+        "'ocpp_message': <Call - unique_id=123456, action=BootNotification, "
+        "payload={'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
+    )
 
-    regex_pattern = r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, payload={" \
-                    r"'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
-
-    with pytest.raises(TypeConstraintViolationError, match=regex_pattern):
+    with pytest.raises(TypeConstraintViolationError) as exception_info:
         validate_payload(call, "1.6")
+    assert ocpp_message in str(exception_info.value)
 
 
 def test_exception_show_triggered_message_format():
-    # The payload is syntactically incorrect, which should trigger a FormatViolationError
-    call = Call(unique_id=123457,
-                action="BootNotification",
-                payload={"syntactically": "incorrect"})
+    # The payload is syntactically incorrect, should trigger a FormatViolationError
+    call = Call(
+        unique_id=123457,
+        action="BootNotification",
+        payload={"syntactically": "incorrect"},
+    )
 
-    regex_pattern = r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, payload={" \
-                    r"'syntactically': 'incorrect'}"
+    ocpp_message = (
+        "'ocpp_message': <Call - unique_id=123457, action=BootNotification, "
+        "payload={'syntactically': 'incorrect'}"
+    )
 
-    with pytest.raises(FormatViolationError, match=regex_pattern):
+    with pytest.raises(FormatViolationError) as exception_info:
         validate_payload(call, "1.6")
+    assert ocpp_message in str(exception_info.value)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,7 @@
-from ocpp.exceptions import ProtocolError
+import pytest
+
+from ocpp.exceptions import ProtocolError, TypeConstraintViolationError, FormatViolationError
+from ocpp.messages import validate_payload, Call
 
 
 def test_exception_with_error_details():
@@ -13,3 +16,29 @@ def test_exception_without_error_details():
 
     assert exception.description == "Payload for Action is incomplete"
     assert exception.details == {}
+
+
+def test_exception_show_triggered_message_type_constraint():
+    # chargePointVendor should be a string, not an integer, so this should raise a TypeConstraintViolationError
+    call = Call(unique_id=123456,
+                action="BootNotification",
+                payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"})
+
+    regex_pattern = r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, payload={" \
+                    r"'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
+
+    with pytest.raises(TypeConstraintViolationError, match=regex_pattern):
+        validate_payload(call, "1.6")
+
+
+def test_exception_show_triggered_message_format():
+    # The payload is syntactically incorrect, which should trigger a FormatViolationError
+    call = Call(unique_id=123457,
+                action="BootNotification",
+                payload={"syntactically": "incorrect"})
+
+    regex_pattern = r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, payload={" \
+                    r"'syntactically': 'incorrect'}"
+
+    with pytest.raises(FormatViolationError, match=regex_pattern):
+        validate_payload(call, "1.6")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,14 +1,18 @@
 import pytest
 
-from ocpp.exceptions import ProtocolError, TypeConstraintViolationError, FormatViolationError
+from ocpp.exceptions import (
+    ProtocolError,
+    TypeConstraintViolationError,
+    FormatViolationError,
+)
 from ocpp.messages import validate_payload, Call
 
 
 def test_exception_with_error_details():
-    exception = ProtocolError("Some error", {'key': 'value'})
+    exception = ProtocolError("Some error", {"key": "value"})
 
     assert exception.description == "Some error"
-    assert exception.details == {'key': 'value'}
+    assert exception.details == {"key": "value"}
 
 
 def test_exception_without_error_details():
@@ -19,26 +23,37 @@ def test_exception_without_error_details():
 
 
 def test_exception_show_triggered_message_type_constraint():
-    # chargePointVendor should be a string, not an integer, so this should raise a TypeConstraintViolationError
-    call = Call(unique_id=123456,
-                action="BootNotification",
-                payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"})
+    """chargePointVendor should be a string, not an integer, so this should
+    raise a TypeConstraintViolationError
+    """
+    call = Call(
+        unique_id=123456,
+        action="BootNotification",
+        payload={"chargePointVendor": 1, "chargePointModel": "SingleSocketCharger"},
+    )
 
-    regex_pattern = r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, payload={" \
-                    r"'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
+    regex_pattern = (
+        r"'ocpp_message': <Call - unique_id=123456, action=BootNotification, payload={"
+        r"'chargePointVendor': 1, 'chargePointModel': 'SingleSocketCharger'}"
+    )
 
     with pytest.raises(TypeConstraintViolationError, match=regex_pattern):
         validate_payload(call, "1.6")
 
 
 def test_exception_show_triggered_message_format():
-    # The payload is syntactically incorrect, which should trigger a FormatViolationError
-    call = Call(unique_id=123457,
-                action="BootNotification",
-                payload={"syntactically": "incorrect"})
+    """The payload is syntactically incorrect, which should trigger a FormatViolationError"""
 
-    regex_pattern = r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, payload={" \
-                    r"'syntactically': 'incorrect'}"
+    call = Call(
+        unique_id=123457,
+        action="BootNotification",
+        payload={"syntactically": "incorrect"},
+    )
+
+    regex_pattern = (
+        r"'ocpp_message': <Call - unique_id=123457, action=BootNotification, payload={"
+        r"'syntactically': 'incorrect'}"
+    )
 
     with pytest.raises(FormatViolationError, match=regex_pattern):
         validate_payload(call, "1.6")


### PR DESCRIPTION
Scope: In case an OCPP validation fails TypeConstraint or Format, we should log which message caused the validation to fail.


We noticed a reproducible TypeConstraintViolation as a reaction to an OCPP message from Etrel Chargers.

A (OCPP) response from the Etrel chargers leads to a a) problem in data type conversion/parsing, b) a debug message that a transmitted string may be too long.