### PR TITLE
feat: Support OCPP spec extensions - Part 1

### DIFF
--- a/ocpp/__init__.py
+++ b/ocpp/__init__.py
@@ -1,0 +1,6 @@
+from ocpp.charge_point import ChargePoint as cp
+from ocpp.messages import OCPPVersion, SchemaValidator
+
+
+class ChargePoint(cp):
+    _schema_validator = SchemaValidator(ocpp_version=OCPPVersion.v201)

--- a/ocpp/__init__.py
+++ b/ocpp/__init__.py
@@ -1,6 +1,0 @@
-from ocpp.charge_point import ChargePoint as cp
-from ocpp.messages import OCPPVersion, SchemaValidator
-
-
-class ChargePoint(cp):
-    _schema_validator = SchemaValidator(ocpp_version=OCPPVersion.v201)

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -178,7 +178,11 @@ class ChargePoint:
             )
 
         if not handlers.get("_skip_schema_validation", False):
-            validate_payload(msg, self._ocpp_version)
+            extension = handlers.get("_extension")
+            if extension:
+                validate_payload(msg, self._ocpp_version, extension=extension)
+            else:
+                validate_payload(msg, self._ocpp_version)
         # OCPP uses camelCase for the keys in the payload. It's more pythonic
         # to use snake_case for keyword arguments. Therefore the keys must be
         # 'translated'. Some examples:

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -5,10 +5,10 @@ import re
 import time
 import uuid
 from dataclasses import asdict
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from ocpp.exceptions import NotSupportedError, OCPPError
-from ocpp.messages import Call, MessageType, unpack, validate_payload
+from ocpp.messages import Call, Extension, MessageType, unpack, validate_payload
 from ocpp.routing import create_route_map
 
 LOGGER = logging.getLogger("ocpp")
@@ -225,7 +225,11 @@ class ChargePoint:
         response = msg.create_call_result(camel_case_payload)
 
         if not handlers.get("_skip_schema_validation", False):
-            validate_payload(response, self._ocpp_version)
+            extension = handlers.get("_extension")
+            if extension:
+                validate_payload(msg, self._ocpp_version, extension=extension)
+            else:
+                validate_payload(msg, self._ocpp_version)
 
         await self._send(response.to_json())
 
@@ -241,7 +245,13 @@ class ChargePoint:
             # when no '_on_after' hook is installed.
             pass
 
-    async def call(self, payload, suppress=True):
+    async def call(
+        self,
+        payload,
+        suppress=True,
+        extension: Optional[Extension] = None,
+        extension_call_result: Optional[object] = None,
+    ):
         """
         Send Call message to client and return payload of response.
 
@@ -261,7 +271,6 @@ class ChargePoint:
         if response is a CallError, then this call will be suppressed. When
         set to False, an exception will be raised for users to handle this
         CallError.
-
         """
         camel_case_payload = snake_to_camel_case(asdict(payload))
 
@@ -271,7 +280,7 @@ class ChargePoint:
             payload=remove_nones(camel_case_payload),
         )
 
-        validate_payload(call, self._ocpp_version)
+        validate_payload(call, self._ocpp_version, extension=extension)
 
         # Use a lock to prevent make sure that only 1 message can be send at a
         # a time.
@@ -294,7 +303,7 @@ class ChargePoint:
             raise response.to_exception()
         else:
             response.action = call.action
-            validate_payload(response, self._ocpp_version)
+            validate_payload(response, self._ocpp_version, extension=extension)
 
         snake_case_payload = camel_to_snake_case(response.payload)
         # Create the correct Payload instance based on the received payload. If
@@ -302,7 +311,10 @@ class ChargePoint:
         # will create a call_result.BootNotificationPayload. If this method is
         # called with a call.HeartbeatPayload, then it will create a
         # call_result.HeartbeatPayload etc.
-        cls = getattr(self._call_result, payload.__class__.__name__)  # noqa
+        if extension:
+            cls = getattr(extension_call_result, payload.__class__.__name__)  # noqa
+        else:
+            cls = getattr(self._call_result, payload.__class__.__name__)  # noqa
         return cls(**snake_case_payload)
 
     async def _get_specific_response(self, unique_id, timeout):

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -27,8 +27,53 @@ from ocpp.exceptions import (
 _validators: Dict[str, Draft4Validator] = {}
 
 
-class Extension(str, Enum):
-    v2x = "v2x"
+class OCPPVersion(str, Enum):
+    v16 = "1.6"
+    v20 = "2.0"
+    v201 = "2.0.1"
+
+
+class SchemaValidator:
+    def __init__(
+        self, ocpp_version: OCPPVersion, path_to_schemas: Optional[str] = None
+    ):
+        self.ocpp_version = ocpp_version
+        self.path_to_schemas = path_to_schemas
+
+    def get_schema_for_call(self, action: str, parse_float: Callable = float):
+        schema_name = action
+        if self.ocpp_version in ["2.0", "2.0.1"]:
+            schema_name += "Request"
+        if self.ocpp_version == "2.0":
+            schema_name += "_v1p0"
+
+        return self._get_validator(schema_name, parse_float=parse_float)
+
+    def get_schema_for_call_result(self, action: str, parse_float: Callable = float):
+        schema_name = action + "Response"
+        if self.ocpp_version == "2.0":
+            schema_name += "_v1p0"
+
+        return self._get_validator(schema_name, parse_float=parse_float)
+
+    def _get_validator(self, schema_name: str, parse_float: Callable = float):
+        if self.path_to_schemas:
+            path = f"{self.path_to_schemas}/{schema_name}.json"
+        else:
+            schemas_dir = "v" + self.ocpp_version.replace(".", "")
+            dir, _ = os.path.split(os.path.realpath(__file__))
+            relative_path = f"{schemas_dir}/schemas/{schema_name}.json"
+            path = os.path.join(dir, relative_path)
+
+        if path in _validators:
+            return _validators[path]
+
+        with open(path, "r", encoding="utf-8-sig") as f:
+            data = f.read()
+            validator = Draft4Validator(json.loads(data, parse_float=parse_float))
+            _validators[path] = validator
+
+        return _validators[path]
 
 
 class _DecimalEncoder(json.JSONEncoder):
@@ -123,62 +168,8 @@ def pack(msg):
     return msg.to_json()
 
 
-def get_validator(
-    message_type_id: int,
-    action: str,
-    ocpp_version: str,
-    parse_float: Callable = float,
-    extension: Optional[Extension] = None,
-) -> Draft4Validator:
-    """
-    Read schema from disk and return as `Draft4Validator`. Instances will be
-    cached for performance reasons.
-
-    The `parse_float` argument can be used to set the conversion method that
-    is used to parse floats. It must be a callable taking 1 argument. By
-    default it is `float()`, but certain schema's require `decimal.Decimal()`.
-    """
-    if ocpp_version not in ["1.6", "2.0", "2.0.1"]:
-        raise ValueError
-
-    schemas_dir = "v" + ocpp_version.replace(".", "")
-    if extension:
-        schemas_dir = f"{schemas_dir}/{extension}"
-
-    schema_name = action
-    if message_type_id == MessageType.CallResult:
-        schema_name += "Response"
-    elif message_type_id == MessageType.Call:
-        if ocpp_version in ["2.0", "2.0.1"]:
-            schema_name += "Request"
-
-    if ocpp_version == "2.0":
-        schema_name += "_v1p0"
-
-    cache_key = schema_name + "_" + ocpp_version
-    if cache_key in _validators:
-        return _validators[cache_key]
-
-    dir, _ = os.path.split(os.path.realpath(__file__))
-    relative_path = f"{schemas_dir}/schemas/{schema_name}.json"
-    path = os.path.join(dir, relative_path)
-
-    # The JSON schemas for OCPP 2.0 start with a byte order mark (BOM)
-    # character. If no encoding is given, reading the schema would fail with:
-    #
-    #     Unexpected UTF-8 BOM (decode using utf-8-sig):
-    with open(path, "r", encoding="utf-8-sig") as f:
-        data = f.read()
-        validator = Draft4Validator(json.loads(data, parse_float=parse_float))
-        _validators[cache_key] = validator
-
-    return _validators[cache_key]
-
-
 def validate_payload(
-    message: Union[Call, CallResult],
-    ocpp_version,
-    extension: Optional[Extension] = None,
+    message: Union[Call, CallResult], schema_validator: SchemaValidator
 ):
     """Validate the payload of the message using JSON schemas."""
     if type(message) not in [Call, CallResult]:
@@ -204,7 +195,7 @@ def validate_payload(
         #
         # Both the schema and the payload must be parsed using the different
         # parser for floats.
-        if ocpp_version == "1.6" and (
+        if schema_validator.ocpp_version == OCPPVersion.v16 and (
             (
                 type(message) == Call
                 and message.action in ["SetChargingProfile", "RemoteStartTransaction"]
@@ -213,24 +204,24 @@ def validate_payload(
                 type(message) == CallResult and message.action == "GetCompositeSchedule"
             )
         ):
-            validator = get_validator(
-                message.message_type_id,
-                message.action,
-                ocpp_version,
-                parse_float=decimal.Decimal,
-                extension=extension,
-            )
-
+            if message.message_type_id == MessageType.Call:
+                validator = schema_validator.get_schema_for_call(
+                    action=message.action, parse_float=decimal.Decimal
+                )
+            elif message.message_type_id == MessageType.CallResult:
+                validator = schema_validator.get_schema_for_call_result(
+                    action=message.action, parse_float=decimal.Decimal
+                )
             message.payload = json.loads(
                 json.dumps(message.payload), parse_float=decimal.Decimal
             )
         else:
-            validator = get_validator(
-                message.message_type_id,
-                message.action,
-                ocpp_version,
-                extension=extension,
-            )
+            if message.message_type_id == MessageType.Call:
+                validator = schema_validator.get_schema_for_call(action=message.action)
+            elif message.message_type_id == MessageType.CallResult:
+                validator = schema_validator.get_schema_for_call_result(
+                    action=message.action
+                )
     except (OSError, json.JSONDecodeError):
         raise NotImplementedError(
             details={"cause": f"Failed to validate action: {message.action}"}

--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -143,7 +143,7 @@ def get_validator(
 
     schemas_dir = "v" + ocpp_version.replace(".", "")
     if extension:
-        schemas_dir = f"{schemas_dir}_{extension}"
+        schemas_dir = f"{schemas_dir}/{extension}"
 
     schema_name = action
     if message_type_id == MessageType.CallResult:

--- a/ocpp/routing.py
+++ b/ocpp/routing.py
@@ -1,9 +1,12 @@
 import functools
+from typing import Optional
+
+from ocpp.messages import Extension
 
 routables = []
 
 
-def on(action, *, skip_schema_validation=False):
+def on(action, *, skip_schema_validation=False, extension: Optional[Extension] = None):
     """
     Function decorator to mark function as handler for specific action. The
     wrapped function may be async or sync.
@@ -49,6 +52,7 @@ def on(action, *, skip_schema_validation=False):
 
         inner._on_action = action
         inner._skip_schema_validation = skip_schema_validation
+        inner._extension = extension
         if func.__name__ not in routables:
             routables.append(func.__name__)
         return inner

--- a/ocpp/routing.py
+++ b/ocpp/routing.py
@@ -134,6 +134,7 @@ def create_route_map(obj):
                     routes[action]["_skip_schema_validation"] = getattr(
                         attr, "_skip_schema_validation", False
                     )
+                    routes[action]["_extension"] = getattr(attr, "_extension", None)
 
                 routes[action][option] = attr
 

--- a/ocpp/routing.py
+++ b/ocpp/routing.py
@@ -1,12 +1,17 @@
 import functools
 from typing import Optional
 
-from ocpp.messages import Extension
+from ocpp.messages import SchemaValidator
 
 routables = []
 
 
-def on(action, *, skip_schema_validation=False, extension: Optional[Extension] = None):
+def on(
+    action,
+    *,
+    skip_schema_validation=False,
+    custom_schema_validator: Optional[SchemaValidator] = None
+):
     """
     Function decorator to mark function as handler for specific action. The
     wrapped function may be async or sync.
@@ -52,7 +57,7 @@ def on(action, *, skip_schema_validation=False, extension: Optional[Extension] =
 
         inner._on_action = action
         inner._skip_schema_validation = skip_schema_validation
-        inner._extension = extension
+        inner._custom_schema_validator = custom_schema_validator
         if func.__name__ not in routables:
             routables.append(func.__name__)
         return inner
@@ -134,7 +139,9 @@ def create_route_map(obj):
                     routes[action]["_skip_schema_validation"] = getattr(
                         attr, "_skip_schema_validation", False
                     )
-                    routes[action]["_extension"] = getattr(attr, "_extension", None)
+                    routes[action]["_custom_schema_validator"] = getattr(
+                        attr, "_custom_schema_validator", None
+                    )
 
                 routes[action][option] = attr
 

--- a/ocpp/v16/__init__.py
+++ b/ocpp/v16/__init__.py
@@ -1,8 +1,6 @@
 from ocpp.charge_point import ChargePoint as cp
-from ocpp.v16 import call, call_result
+from ocpp.messages import OCPPVersion, SchemaValidator
 
 
 class ChargePoint(cp):
-    _call = call
-    _call_result = call_result
-    _ocpp_version = "1.6"
+    _schema_validator = SchemaValidator(ocpp_version=OCPPVersion.v16)

--- a/ocpp/v20/__init__.py
+++ b/ocpp/v20/__init__.py
@@ -1,8 +1,6 @@
 from ocpp.charge_point import ChargePoint as cp
-from ocpp.v20 import call, call_result
+from ocpp.messages import OCPPVersion, SchemaValidator
 
 
 class ChargePoint(cp):
-    _call = call
-    _call_result = call_result
-    _ocpp_version = "2.0"
+    _schema_validator = SchemaValidator(ocpp_version=OCPPVersion.v20)

--- a/ocpp/v201/__init__.py
+++ b/ocpp/v201/__init__.py
@@ -1,8 +1,6 @@
 from ocpp.charge_point import ChargePoint as cp
-from ocpp.v201 import call, call_result
+from ocpp.messages import SchemaValidator
 
 
 class ChargePoint(cp):
-    _call = call
-    _call_result = call_result
-    _ocpp_version = "2.0.1"
+    _schema_validator = SchemaValidator(ocpp_version="2.0.1")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,7 +5,9 @@ from ocpp.exceptions import (
     ProtocolError,
     TypeConstraintViolationError,
 )
-from ocpp.messages import Call, validate_payload
+from ocpp.messages import Call, OCPPVersion, SchemaValidator, validate_payload
+
+v16_validator = SchemaValidator(ocpp_version=OCPPVersion.v16)
 
 
 def test_exception_with_error_details():
@@ -36,7 +38,7 @@ def test_exception_show_triggered_message_type_constraint():
     )
 
     with pytest.raises(TypeConstraintViolationError) as exception_info:
-        validate_payload(call, "1.6")
+        validate_payload(call, v16_validator)
     assert ocpp_message in str(exception_info.value)
 
 
@@ -54,5 +56,5 @@ def test_exception_show_triggered_message_format():
     )
 
     with pytest.raises(FormatViolationError) as exception_info:
-        validate_payload(call, "1.6")
+        validate_payload(call, v16_validator)
     assert ocpp_message in str(exception_info.value)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -349,3 +349,16 @@ def test_validate_set_maxlength_violation_payload():
 
     with pytest.raises(TypeConstraintViolationError):
         validate_payload(message, ocpp_version="1.6")
+
+
+def test_validate_v2x_extension_payload():
+    """
+    Tests that the correct schema is used when testing a V2X message
+    """
+    message = Call(
+        unique_id="1234",
+        action="ModifyChargingProfile",
+        payload={"chargingProfileId": 1},
+    )
+
+    validate_payload(message, ocpp_version="2.0.1", extension="v2x")

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,5 +1,6 @@
 import decimal
 import json
+import os
 from datetime import datetime
 
 import pytest
@@ -17,14 +18,17 @@ from ocpp.messages import (
     Call,
     CallError,
     CallResult,
-    MessageType,
+    OCPPVersion,
+    SchemaValidator,
     _DecimalEncoder,
     _validators,
-    get_validator,
     unpack,
     validate_payload,
 )
 from ocpp.v16.enums import Action
+
+v16_validator = SchemaValidator(ocpp_version=OCPPVersion.v16)
+v20_validator = SchemaValidator(ocpp_version=OCPPVersion.v20)
 
 
 def test_unpack_with_invalid_json():
@@ -69,9 +73,10 @@ def test_get_validator_with_valid_name():
     """
     Test if correct validator is returned and if validator is added to cache.
     """
-    schema = get_validator(MessageType.Call, "Reset", ocpp_version="1.6")
+    _validators.clear()
+    schema = v16_validator.get_schema_for_call(action="Reset")
 
-    assert schema == _validators["Reset_1.6"]
+    assert schema == list(_validators.values())[0]
     assert schema.schema == {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "ResetRequest",
@@ -93,7 +98,7 @@ def test_get_validator_with_invalid_name():
     Test if OSError is raised when schema validation file cannnot be found.
     """
     with pytest.raises(OSError):
-        get_validator(MessageType.Call, "non-existing", ocpp_version="1.6")
+        v16_validator.get_schema_for_call(action="non-existing")
 
 
 def test_validate_set_charging_profile_payload():
@@ -122,7 +127,7 @@ def test_validate_set_charging_profile_payload():
         },
     )
 
-    validate_payload(message, ocpp_version="1.6")
+    validate_payload(message, schema_validator=v16_validator)
 
 
 def test_validate_get_composite_profile_payload():
@@ -147,11 +152,11 @@ def test_validate_get_composite_profile_payload():
         },
     )
 
-    validate_payload(message, ocpp_version="1.6")
+    validate_payload(message, schema_validator=v16_validator)
 
 
-@pytest.mark.parametrize("ocpp_version", ["1.6", "2.0"])
-def test_validate_payload_with_valid_payload(ocpp_version):
+@pytest.mark.parametrize("validator", [v16_validator, v20_validator])
+def test_validate_payload_with_valid_payload(validator):
     """
     Test if validate_payload doesn't return any exceptions when it's
     validating a valid payload.
@@ -162,7 +167,7 @@ def test_validate_payload_with_valid_payload(ocpp_version):
         payload={"currentTime": datetime.now().isoformat()},
     )
 
-    validate_payload(message, ocpp_version=ocpp_version)
+    validate_payload(message, schema_validator=validator)
 
 
 def test_validate_payload_with_invalid_additional_properties_payload():
@@ -177,7 +182,7 @@ def test_validate_payload_with_invalid_additional_properties_payload():
     )
 
     with pytest.raises(FormatViolationError):
-        validate_payload(message, ocpp_version="1.6")
+        validate_payload(message, schema_validator=v16_validator)
 
 
 def test_validate_payload_with_invalid_type_payload():
@@ -197,7 +202,7 @@ def test_validate_payload_with_invalid_type_payload():
     )
 
     with pytest.raises(TypeConstraintViolationError):
-        validate_payload(message, ocpp_version="1.6")
+        validate_payload(message, schema_validator=v16_validator)
 
 
 def test_validate_payload_with_invalid_missing_property_payload():
@@ -217,7 +222,7 @@ def test_validate_payload_with_invalid_missing_property_payload():
     )
 
     with pytest.raises(ProtocolError):
-        validate_payload(message, ocpp_version="1.6")
+        validate_payload(message, schema_validator=v16_validator)
 
 
 def test_validate_payload_with_invalid_message_type_id():
@@ -226,7 +231,7 @@ def test_validate_payload_with_invalid_message_type_id():
     a message type id other than 2, Call, or 3, CallError.
     """
     with pytest.raises(ValidationError):
-        validate_payload(dict(), ocpp_version="1.6")
+        validate_payload(dict(), schema_validator=v16_validator)
 
 
 def test_validate_payload_with_non_existing_schema():
@@ -241,7 +246,7 @@ def test_validate_payload_with_non_existing_schema():
     )
 
     with pytest.raises(NotImplementedError):
-        validate_payload(message, ocpp_version="1.6")
+        validate_payload(message, schema_validator=v16_validator)
 
 
 def test_call_error_representation():
@@ -330,7 +335,7 @@ def test_validate_meter_values_hertz():
         },
     )
 
-    validate_payload(message, ocpp_version="1.6")
+    validate_payload(message, schema_validator=v16_validator)
 
 
 def test_validate_set_maxlength_violation_payload():
@@ -348,17 +353,17 @@ def test_validate_set_maxlength_violation_payload():
     )
 
     with pytest.raises(TypeConstraintViolationError):
-        validate_payload(message, ocpp_version="1.6")
+        validate_payload(message, schema_validator=v16_validator)
 
 
-def test_validate_v2x_extension_payload():
-    """
-    Tests that the correct schema is used when testing a V2X message
-    """
+def test_custom_schema_validation():
     message = Call(
         unique_id="1234",
-        action="ModifyChargingProfile",
-        payload={"chargingProfileId": 1},
+        action="Heartbeat",
+        payload={},
     )
 
-    validate_payload(message, ocpp_version="2.0.1", extension="v2x")
+    path = os.getcwd() + "/ocpp/v201/schemas"
+
+    validator = SchemaValidator(ocpp_version=OCPPVersion.v201, path_to_schemas=path)
+    validate_payload(message=message, schema_validator=validator)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -33,11 +33,11 @@ def test_create_route_map():
             "_on_action": cp.on_heartbeat,
             "_after_action": cp.after_heartbeat,
             "_skip_schema_validation": True,
-            "_extension": None,
+            "_custom_schema_validator": None,
         },
         Action.MeterValues: {
             "_on_action": cp.meter_values,
             "_skip_schema_validation": False,
-            "_extension": None,
+            "_custom_schema_validator": None,
         },
     }

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -33,9 +33,11 @@ def test_create_route_map():
             "_on_action": cp.on_heartbeat,
             "_after_action": cp.after_heartbeat,
             "_skip_schema_validation": True,
+            "_extension": None,
         },
         Action.MeterValues: {
             "_on_action": cp.meter_values,
             "_skip_schema_validation": False,
+            "_extension": None,
         },
     }


### PR DESCRIPTION
This PR adds support for OCPP spec extensions. This is the first PR adding support for V2X extensions but also enabling support for potential future extensions from the OCA. The V2X extension types, schemas, examples, and unit tests would come in a future PR.