### PR TITLE
Fix publish-to-pypi build

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Gets the tag version
       id: context

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -33,7 +33,7 @@ jobs:
         proj_version=$(poetry version -s)
         if [ $proj_version != $TAG_VERSION ]; then echo "Version $proj_version, defined in pyproject.toml, does not match TAG $TAG_VERSION of this release"; exit 3; fi
         poetry update
-        poetry publish --build --dry-run -u __token__ -p $PYPI_TOKEN
+        poetry publish --build -u __token__ -p $PYPI_TOKEN
       env:
         TAG_VERSION: ${{ steps.context.outputs.TAG_VERSION }}
         PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10.0
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10.0
+        python-version: 3.10
 
     - name: Gets the tag version
       id: context
@@ -33,7 +33,7 @@ jobs:
         proj_version=$(poetry version -s)
         if [ $proj_version != $TAG_VERSION ]; then echo "Version $proj_version, defined in pyproject.toml, does not match TAG $TAG_VERSION of this release"; exit 3; fi
         poetry update
-        poetry publish --build -u __token__ -p $PYPI_TOKEN
+        poetry publish --build --dry-run -u __token__ -p $PYPI_TOKEN
       env:
         TAG_VERSION: ${{ steps.context.outputs.TAG_VERSION }}
         PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
[The publish-to-pypi build failed for 0.16.0.](https://github.com/mobilityhouse/ocpp/actions/runs/3838953465/jobs/6536318630). It seems that the issue is caused by the lack of quotes around value for field 'python-version'. 