### PR TITLE
fix: child_certificate_hash_data type

### DIFF
--- a/ocpp/v201/datatypes.py
+++ b/ocpp/v201/datatypes.py
@@ -67,7 +67,7 @@ class CertificateHashDataChainType:
 
     certificate_type: enums.GetCertificateIdUseType
     certificate_hash_data: CertificateHashDataType
-    child_certificate_hash_data: CertificateHashDataType
+    child_certificate_hash_data: Optional[List[CertificateHashDataType]]
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes the `childCertificateHashData` field in the `CertificateHashDataChainType` as specified in OCPP 2.0.1.