### PR TITLE
feat: add optional param for passing an unique_id to call method.

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -237,7 +237,7 @@ class ChargePoint:
             # when no '_on_after' hook is installed.
             pass
 
-    async def call(self, payload, suppress=True):
+    async def call(self, payload, suppress=True, unique_id=None):
         """
         Send Call message to client and return payload of response.
 
@@ -261,8 +261,12 @@ class ChargePoint:
         """
         camel_case_payload = snake_to_camel_case(asdict(payload))
 
+        unique_id = (
+            unique_id if unique_id is not None else str(self._unique_id_generator())
+        )
+
         call = Call(
-            unique_id=str(self._unique_id_generator()),
+            unique_id=unique_id,
             action=payload.__class__.__name__[:-7],
             payload=remove_nones(camel_case_payload),
         )

--- a/tests/v16/conftest.py
+++ b/tests/v16/conftest.py
@@ -40,8 +40,8 @@ def base_central_system(connection):
 @pytest.fixture
 def mock_boot_request():
     return call.BootNotificationPayload(
-        charge_point_vendor="ICU Eve Mini",
-        charge_point_model="ICU Eve Mini",
+        charge_point_vendor="dummy_vendor",
+        charge_point_model="dummy_model",
     )
 
 

--- a/tests/v16/conftest.py
+++ b/tests/v16/conftest.py
@@ -1,4 +1,9 @@
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # Python 3.7 and below don't include unittest.mock.AsyncMock. Hence,
+    # we need to resolve to a package on pypi.
+    from asynctest import CoroutineMock as AsyncMock
 
 import pytest
 

--- a/tests/v16/conftest.py
+++ b/tests/v16/conftest.py
@@ -1,7 +1,9 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
-from ocpp.messages import Call
-from ocpp.v16 import ChargePoint
+from ocpp.messages import Call, CallResult
+from ocpp.v16 import ChargePoint, call
 from ocpp.v16.enums import Action
 
 
@@ -33,3 +35,32 @@ def base_central_system(connection):
     cs._unique_id_generator = lambda: 1337
 
     return cs
+
+
+@pytest.fixture
+def mock_boot_request():
+    return call.BootNotificationPayload(
+        charge_point_vendor="ICU Eve Mini",
+        charge_point_model="ICU Eve Mini",
+    )
+
+
+@pytest.fixture
+def mock_base_central_system(base_central_system):
+    mock_result_call = CallResult(
+        unique_id=str(base_central_system._unique_id_generator()),
+        action="BootNotification",
+        payload={
+            "currentTime": "2018-05-29T17:37:05.495259",
+            "interval": 350,
+            "status": "Accepted",
+        },
+    )
+
+    base_central_system._send = AsyncMock()
+
+    mock_response = AsyncMock()
+    mock_response.return_value = mock_result_call
+    base_central_system._get_specific_response = mock_response
+
+    return base_central_system

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -191,3 +191,38 @@ async def test_suppress_call_error(base_central_system):
 
     payload = call.ClearCachePayload()
     await base_central_system.call(payload)
+
+
+@pytest.mark.asyncio
+async def test_call_with_unique_id_should_return_same_id(
+    mock_boot_request, mock_base_central_system
+):
+
+    expected_unique_id = "12345"
+    # Call the method being tested with a unique_id as a parameter
+    await mock_base_central_system.call(mock_boot_request, unique_id=expected_unique_id)
+    (
+        actual_unique_id,
+        _,
+    ) = mock_base_central_system._get_specific_response.call_args_list[0][0]
+
+    # Check the actual unique id is equals to the one passed to the call method
+    assert actual_unique_id == expected_unique_id
+
+
+@pytest.mark.asyncio
+async def test_call_without_unique_id_should_return_a_random_value(
+    mock_boot_request, mock_base_central_system
+):
+
+    expected_unique_id = str(mock_base_central_system._unique_id_generator())
+
+    # Call the method being tested without passing a unique_id as a parameter
+    await mock_base_central_system.call(mock_boot_request)
+
+    (
+        actual_unique_id,
+        _,
+    ) = mock_base_central_system._get_specific_response.call_args_list[0][0]
+    # Check the actual unique id is equals to the one internally generated
+    assert actual_unique_id == expected_unique_id

--- a/tests/v20/conftest.py
+++ b/tests/v20/conftest.py
@@ -5,6 +5,12 @@ import pytest
 from ocpp.messages import Call, CallResult
 from ocpp.v20 import ChargePoint, call
 
+chargingStation = {
+    "vendorName": "ICU Eve Mini",
+    "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
+    "model": "ICU Eve Mini",
+}
+
 
 @pytest.fixture
 def heartbeat_call():
@@ -18,11 +24,7 @@ def boot_notification_call():
         action="BootNotification",
         payload={
             "reason": "PowerUp",
-            "chargingStation": {
-                "vendorName": "ICU Eve Mini",
-                "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
-                "model": "ICU Eve Mini",
-            },
+            "chargingStation": chargingStation,
         },
     ).to_json()
 
@@ -43,11 +45,7 @@ def base_central_system(connection):
 def mock_boot_request():
     return call.BootNotificationPayload(
         reason="PowerUp",
-        charging_station={
-            "vendorName": "ICU Eve Mini",
-            "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
-            "model": "ICU Eve Mini",
-        },
+        charging_station=chargingStation,
     )
 
 

--- a/tests/v20/conftest.py
+++ b/tests/v20/conftest.py
@@ -1,4 +1,9 @@
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # Python 3.7 and below don't include unittest.mock.AsyncMock. Hence,
+    # we need to resolve to a package on pypi.
+    from asynctest import CoroutineMock as AsyncMock
 
 import pytest
 

--- a/tests/v20/conftest.py
+++ b/tests/v20/conftest.py
@@ -1,7 +1,9 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
-from ocpp.messages import Call
-from ocpp.v20 import ChargePoint
+from ocpp.messages import Call, CallResult
+from ocpp.v20 import ChargePoint, call
 
 
 @pytest.fixture
@@ -35,3 +37,36 @@ def base_central_system(connection):
     cs._unique_id_generator = lambda: 1337
 
     return cs
+
+
+@pytest.fixture
+def mock_boot_request():
+    return call.BootNotificationPayload(
+        reason="PowerUp",
+        charging_station={
+            "vendorName": "ICU Eve Mini",
+            "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
+            "model": "ICU Eve Mini",
+        },
+    )
+
+
+@pytest.fixture
+def mock_base_central_system(base_central_system):
+    mock_result_call = CallResult(
+        unique_id=str(base_central_system._unique_id_generator()),
+        action="BootNotification",
+        payload={
+            "currentTime": "2018-05-29T17:37:05.495259",
+            "interval": 350,
+            "status": "Accepted",
+        },
+    )
+
+    base_central_system._send = AsyncMock()
+
+    mock_response = AsyncMock()
+    mock_response.return_value = mock_result_call
+    base_central_system._get_specific_response = mock_response
+
+    return base_central_system

--- a/tests/v20/test_v20_charge_point.py
+++ b/tests/v20/test_v20_charge_point.py
@@ -83,3 +83,38 @@ async def test_route_message_with_no_route(base_central_system, heartbeat_call):
             separators=(",", ":"),
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_call_with_unique_id_should_return_same_id(
+    mock_boot_request, mock_base_central_system
+):
+
+    expected_unique_id = "12345"
+    # Call the method being tested with a unique_id as a parameter
+    await mock_base_central_system.call(mock_boot_request, unique_id=expected_unique_id)
+    (
+        actual_unique_id,
+        _,
+    ) = mock_base_central_system._get_specific_response.call_args_list[0][0]
+
+    # Check the actual unique id is equals to the one passed to the call method
+    assert actual_unique_id == expected_unique_id
+
+
+@pytest.mark.asyncio
+async def test_call_without_unique_id_should_return_a_random_value(
+    mock_boot_request, mock_base_central_system
+):
+
+    expected_unique_id = str(mock_base_central_system._unique_id_generator())
+
+    # Call the method being tested without passing a unique_id as a parameter
+    await mock_base_central_system.call(mock_boot_request)
+
+    (
+        actual_unique_id,
+        _,
+    ) = mock_base_central_system._get_specific_response.call_args_list[0][0]
+    # Check the actual unique id is equals to the one internally generated
+    assert actual_unique_id == expected_unique_id

--- a/tests/v201/conftest.py
+++ b/tests/v201/conftest.py
@@ -70,36 +70,3 @@ def mock_base_central_system(base_central_system):
     base_central_system._get_specific_response = mock_response
 
     return base_central_system
-
-
-@pytest.fixture
-def mock_boot_request():
-    return call.BootNotificationPayload(
-        reason="PowerUp",
-        charging_station={
-            "vendorName": "ICU Eve Mini",
-            "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
-            "model": "ICU Eve Mini",
-        },
-    )
-
-
-@pytest.fixture
-def mock_base_central_system(base_central_system):
-    mock_result_call = CallResult(
-        unique_id=str(base_central_system._unique_id_generator()),
-        action="BootNotification",
-        payload={
-            "currentTime": "2018-05-29T17:37:05.495259",
-            "interval": 350,
-            "status": "Accepted",
-        },
-    )
-
-    base_central_system._send = AsyncMock()
-
-    mock_response = AsyncMock()
-    mock_response.return_value = mock_result_call
-    base_central_system._get_specific_response = mock_response
-
-    return base_central_system

--- a/tests/v201/conftest.py
+++ b/tests/v201/conftest.py
@@ -1,7 +1,9 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
-from ocpp.messages import Call
-from ocpp.v201 import ChargePoint
+from ocpp.messages import Call, CallResult
+from ocpp.v201 import ChargePoint, call
 
 
 @pytest.fixture
@@ -35,3 +37,69 @@ def base_central_system(connection):
     cs._unique_id_generator = lambda: 1337
 
     return cs
+
+
+@pytest.fixture
+def mock_boot_request():
+    return call.BootNotificationPayload(
+        reason="PowerUp",
+        charging_station={
+            "vendorName": "ICU Eve Mini",
+            "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
+            "model": "ICU Eve Mini",
+        },
+    )
+
+
+@pytest.fixture
+def mock_base_central_system(base_central_system):
+    mock_result_call = CallResult(
+        unique_id=str(base_central_system._unique_id_generator()),
+        action="BootNotification",
+        payload={
+            "currentTime": "2018-05-29T17:37:05.495259",
+            "interval": 350,
+            "status": "Accepted",
+        },
+    )
+
+    base_central_system._send = AsyncMock()
+
+    mock_response = AsyncMock()
+    mock_response.return_value = mock_result_call
+    base_central_system._get_specific_response = mock_response
+
+    return base_central_system
+
+
+@pytest.fixture
+def mock_boot_request():
+    return call.BootNotificationPayload(
+        reason="PowerUp",
+        charging_station={
+            "vendorName": "ICU Eve Mini",
+            "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
+            "model": "ICU Eve Mini",
+        },
+    )
+
+
+@pytest.fixture
+def mock_base_central_system(base_central_system):
+    mock_result_call = CallResult(
+        unique_id=str(base_central_system._unique_id_generator()),
+        action="BootNotification",
+        payload={
+            "currentTime": "2018-05-29T17:37:05.495259",
+            "interval": 350,
+            "status": "Accepted",
+        },
+    )
+
+    base_central_system._send = AsyncMock()
+
+    mock_response = AsyncMock()
+    mock_response.return_value = mock_result_call
+    base_central_system._get_specific_response = mock_response
+
+    return base_central_system

--- a/tests/v201/conftest.py
+++ b/tests/v201/conftest.py
@@ -1,4 +1,9 @@
-from unittest.mock import AsyncMock
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # Python 3.7 and below don't include unittest.mock.AsyncMock. Hence,
+    # we need to resolve to a package on pypi.
+    from asynctest import CoroutineMock as AsyncMock
 
 import pytest
 

--- a/tests/v201/conftest.py
+++ b/tests/v201/conftest.py
@@ -5,6 +5,12 @@ import pytest
 from ocpp.messages import Call, CallResult
 from ocpp.v201 import ChargePoint, call
 
+chargingStation = {
+    "vendorName": "ICU Eve Mini",
+    "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
+    "model": "ICU Eve Mini",
+}
+
 
 @pytest.fixture
 def heartbeat_call():
@@ -18,11 +24,7 @@ def boot_notification_call():
         action="BootNotification",
         payload={
             "reason": "PowerUp",
-            "chargingStation": {
-                "vendorName": "ICU Eve Mini",
-                "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
-                "model": "ICU Eve Mini",
-            },
+            "chargingStation": chargingStation,
         },
     ).to_json()
 
@@ -43,11 +45,7 @@ def base_central_system(connection):
 def mock_boot_request():
     return call.BootNotificationPayload(
         reason="PowerUp",
-        charging_station={
-            "vendorName": "ICU Eve Mini",
-            "firmwareVersion": "#1:3.4.0-2990#N:217H;1.0-223",
-            "model": "ICU Eve Mini",
-        },
+        charging_station=chargingStation,
     )
 
 

--- a/tests/v201/test_v201_charge_point.py
+++ b/tests/v201/test_v201_charge_point.py
@@ -83,3 +83,38 @@ async def test_route_message_with_no_route(base_central_system, heartbeat_call):
             separators=(",", ":"),
         )
     )
+
+
+@pytest.mark.asyncio
+async def test_call_with_unique_id_should_return_same_id(
+    mock_boot_request, mock_base_central_system
+):
+
+    expected_unique_id = "12345"
+    # Call the method being tested with a unique_id as a parameter
+    await mock_base_central_system.call(mock_boot_request, unique_id=expected_unique_id)
+    (
+        actual_unique_id,
+        _,
+    ) = mock_base_central_system._get_specific_response.call_args_list[0][0]
+
+    # Check the actual unique id is equals to the one passed to the call method
+    assert actual_unique_id == expected_unique_id
+
+
+@pytest.mark.asyncio
+async def test_call_without_unique_id_should_return_a_random_value(
+    mock_boot_request, mock_base_central_system
+):
+
+    expected_unique_id = str(mock_base_central_system._unique_id_generator())
+
+    # Call the method being tested without passing a unique_id as a parameter
+    await mock_base_central_system.call(mock_boot_request)
+
+    (
+        actual_unique_id,
+        _,
+    ) = mock_base_central_system._get_specific_response.call_args_list[0][0]
+    # Check the actual unique id is equals to the one internally generated
+    assert actual_unique_id == expected_unique_id


### PR DESCRIPTION
This PR adds:
-An additional optional parameter to the `call` method. 

This is needed for requirement E-13 on OCPP2.0.1 when the CS needs to retry sending a transaction message with the same ID.
Currently, when the `call` method is called, a `Call` object is created with a new random ID. 