### PR TITLE
Update poetry in CI to 1.5.1

### DIFF
--- a/.github/actions/setup-python-build-env/action.yml
+++ b/.github/actions/setup-python-build-env/action.yml
@@ -8,4 +8,4 @@ runs:
     shell: bash
     run: |
       pip install --upgrade pip
-      pip install --user "poetry==1.1.11"
+      pip install --user "poetry==1.5.1"


### PR DESCRIPTION
Currently, the build requires `poetry` 1.1.11.
That version of `poetry` is already 2 years old.

While working on #452, this old version caused trouble. As part of #452, I've to add new development dependency.
As result, `poetry.lock` is regenerated. Unfortunately, the build fails because the lock file is incompatible with `poetry` 1.1.11. See https://github.com/mobilityhouse/ocpp/actions/runs/5611599332/jobs/10268147947?pr=451

Fixes #455