### PR TITLE
Add `FormationError` and `OccurrenceConstraintViolationError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 ## 0.21.0 (2023-10-19) 
 
 - [#492] Minor fixes _handle_call doc string  - Thanks @drc38
-
 - [#485](https://github.com/mobilityhouse/ocpp/issues/485) Update documents for 2.0.1 to lastest; removed 2.0 docs
 - [#412](https://github.com/mobilityhouse/ocpp/issues/412) Add default value to 1.6 AuthorizationData datatype, id_tag_info
 - [#141](https://github.com/mobilityhouse/ocpp/issues/141) Add to docs OCPP 1.6 Security White Paper Ed 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 
+- [#381](https://github.com/mobilityhouse/ocpp/issues/381) FormatViolation serialization bug with OCPP 1.6-J
 - [#485](https://github.com/mobilityhouse/ocpp/issues/485) Update documents for 2.0.1 to lastest; removed 2.0 docs
 - [#412](https://github.com/mobilityhouse/ocpp/issues/412) Add default value to 1.6 AuthorizationData datatype, id_tag_info
 - [#141](https://github.com/mobilityhouse/ocpp/issues/141) Add to docs OCPP 1.6 Security White Paper Ed 2

--- a/ocpp/exceptions.py
+++ b/ocpp/exceptions.py
@@ -68,9 +68,28 @@ class SecurityError(OCPPError):
 
 
 class FormatViolationError(OCPPError):
+    """
+    Not strict OCPP 1.6 - see FormationViolationError
+    Valid OCPP 2.0.1
+    """
+
     code = "FormatViolation"
     default_description = (
         "Payload for Action is syntactically incorrect or " "structure for Action"
+    )
+
+
+class FormationViolationError(OCPPError):
+    """
+    To allow for strict OCPP 1.6 compliance
+        5. Known issues that will not be fixed
+        5.2. Page 14, par 4.2.3. CallError: incorrect name in enum: FormationViolation
+        Incorrect name in enum: FormationViolation
+    """
+
+    code = "FormationViolation"
+    default_description = (
+        "Payload for Action is syntactically incorrect or structure for Action"
     )
 
 
@@ -83,7 +102,29 @@ class PropertyConstraintViolationError(OCPPError):
 
 
 class OccurenceConstraintViolationError(OCPPError):
+    """
+    To allow for strict OCPP 1.6 compliance
+    ocpp-j-1.6-errata-sheet.pdf
+        5. Known issues that will not be fixed
+        5.1. Page 14, par 4.2.3: CallError: Typo in enum
+        Typo in enum: OccurenceConstraintViolation
+    """
+
     code = "OccurenceConstraintViolation"
+    default_description = (
+        "Payload for Action is syntactically correct but "
+        "at least one of the fields violates occurence "
+        "constraints"
+    )
+
+
+class OccurrenceConstraintViolationError(OCPPError):
+    """
+    Not strict OCPP 1.6 - see OccurenceConstraintViolationError
+    Valid OCPP 2.0.1
+    """
+
+    code = "OccurrenceConstraintViolation"
     default_description = (
         "Payload for Action is syntactically correct but "
         "at least one of the fields violates occurence "


### PR DESCRIPTION
In OCPP 1.6, two errors were misspelled. "FormationViolation" Error should be "FormatViolation" Error, "OccurenceConstraintViolation" Error should be "OccurrenceConstraintViolation" Error.

The OCA decided not to correct the spelling in OCPP 1.6, since that would be a breaking change. FormationViolation has been fixed as of OCPP 2.0.1. OccurenceConstraintViolation Error is used for 1.6 and 2.0.1. "OccurrenceConstraintViolation" Error is used for OCPP 2.1 and up.

This library doesn't support "FormationViolation" Error (for OCPP 1.6 and up)

This commit  adds support for those errors.

See the discussion at https://github.com/mobilityhouse/ocpp/issues/381 and OCPP 1.6-J Errata sheet v1.0, section 5 "Known issues that won't be fixed".