### PR TITLE
fix: add missing tech_info attribute to v2.0.1 EventDataType

### DIFF
--- a/ocpp/v201/datatypes.py
+++ b/ocpp/v201/datatypes.py
@@ -395,6 +395,7 @@ class EventDataType:
     variable: VariableType
     cause: Optional[int] = None
     tech_code: Optional[str] = None
+    tech_info: Optional[str] = None
     cleared: Optional[bool] = None
     transaction_id: Optional[str] = None
     variable_monitoring_id: Optional[int] = None


### PR DESCRIPTION
The V2.0.1 datatype `EventDataType` is missing an optional string attribute for techInfo.