### PR TITLE
Amend validation error raised

### DIFF
--- a/ocpp/messages.py
+++ b/ocpp/messages.py
@@ -13,7 +13,6 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 
 from ocpp.exceptions import (
     FormatViolationError,
-    NotImplementedError,
     OCPPError,
     PropertyConstraintViolationError,
     ProtocolError,
@@ -217,10 +216,14 @@ def validate_payload(message: Union[Call, CallResult], ocpp_version: str) -> Non
             validator = get_validator(
                 message.message_type_id, message.action, ocpp_version
             )
-    except (OSError, json.JSONDecodeError):
-        raise NotImplementedError(
-            details={"cause": f"Failed to validate action: {message.action}"}
+    except OSError:
+        raise ValidationError(
+            details={"cause": f"JSON validation schema not found for action: {message.action}"}
         )
+    except json.JSONDecodeError:
+       raise ValidationError(
+            details={"cause": f"Error in decoding JSON validation schema for action: {message.action}"}
+       )
 
     try:
         validator.validate(message.payload)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -6,7 +6,6 @@ import pytest
 
 from ocpp.exceptions import (
     FormatViolationError,
-    NotImplementedError,
     PropertyConstraintViolationError,
     ProtocolError,
     TypeConstraintViolationError,
@@ -240,7 +239,7 @@ def test_validate_payload_with_non_existing_schema():
         payload={"invalid_key": True},
     )
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValidationError):
         validate_payload(message, ocpp_version="1.6")
 
 


### PR DESCRIPTION
With the incorporation of #494 an OSError should only be raised on edge cases eg if the json schema file is corrupt. NotImplementedError and NotSupportedError errors will be raised prior to the json validation occurring, taking care of when the schema doesn't exist.