### PR TITLE
update to match Appendix 2. Standardized Units Of Measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- [#510](https://github.com/mobilityhouse/ocpp/issues/510) v2.0.1 UnitOfMeasureType - Enums missing and update docstring to allow use for variableCharacteristics
+
 ## 0.22.0 (2023-11-03)
 
 - [#493](https://github.com/mobilityhouse/ocpp/issues/493) Reduce use of NotSupportedError in favor of NotImplementedError. Thanks [drc38](@https://github.com/drc38).

--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -773,6 +773,7 @@ class UnitOfMeasure(str, Enum):
     k = "K"
     percent = "Percent"
     hertz = "Hertz"
+    b = "Bytes"
 
 
 class UnlockStatus(str, Enum):


### PR DESCRIPTION
Missing Bytes - see OCPP 2.0.1 Appendix 2. Standardized Units of Measure