### PR TITLE
fix: DataTransfer data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 
+- [#537] (https://github.com/mobilityhouse/ocpp/pull/537) Fix DataTransfer data types 
 - [#531] (https://github.com/mobilityhouse/ocpp/pull/531) Add 1.6 security extension datatypes
 =======
 - [#528](https://github.com/mobilityhouse/ocpp/issues/528) v2.0.1 CertificateHashDataChainType childCertificateHashData requires the default of None

--- a/ocpp/v201/call.py
+++ b/ocpp/v201/call.py
@@ -90,7 +90,7 @@ class CustomerInformationPayload:
 class DataTransferPayload:
     vendor_id: str
     message_id: Optional[str] = None
-    data: Optional[str] = None
+    data: Optional[Any] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -87,7 +87,7 @@ class CustomerInformationPayload:
 class DataTransferPayload:
     status: str
     status_info: Optional[Dict] = None
-    data: Optional[Dict] = None
+    data: Optional[Any] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 


### PR DESCRIPTION
In 2.0.1 both DataTransferRequest and DataTransferResponse have a field called `data` which is defined as `AnyType` so I believe these should both by of type `Any` here