### PR TITLE
ChargePoint._handle_call return response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log
 
+- [#539](https://github.com/mobilityhouse/ocpp/issues/539) Add ChargePoint._handle_call return value
 - [#516](https://github.com/mobilityhouse/ocpp/issues/516) OCPP 2.0.1 add additional security events from v1.3
-- [#537] (https://github.com/mobilityhouse/ocpp/pull/537) Fix DataTransfer data types 
+- [#537](https://github.com/mobilityhouse/ocpp/pull/537) Fix DataTransfer data types 
 
 ## 0.23.0 (2023-11-30)
 

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -267,6 +267,7 @@ class ChargePoint:
             # '_on_after' hooks are not required. Therefore ignore exception
             # when no '_on_after' hook is installed.
             pass
+        return response
 
     async def call(self, payload, suppress=True, unique_id=None):
         """


### PR DESCRIPTION
- To log OCPP call results to `ocpp_index`, we are currently relying on a decorator that decorates the `_on_action` handlers.
- At the level of those handlers we do not have access to the `message.unique_id` which  is a logging requirement, for that we decided to use `ChargePoint._handle_call` method.
- By doing so we lost access to the `response` which is also a required field for the logging.
- To resolve this, we want to make `ChargePoint._handle_call` has the `response` as return value. 

[CHAR-3326]: https://mobilityhouse.atlassian.net/browse/CHAR-3326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ