### PR TITLE
Bump to 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change log
 
-- [#539](https://github.com/mobilityhouse/ocpp/issues/539) Add ChargePoint._handle_call return value
-- [#266](https://github.com/mobilityhouse/ocpp/issues/266) Central System documentation link
-=======
-- [#516](https://github.com/mobilityhouse/ocpp/issues/516) OCPP 2.0.1 add additional security events from v1.3
-- [#537](https://github.com/mobilityhouse/ocpp/pull/537) Fix DataTransfer data types 
+## 0.24.0 (2023-12-07)
 
+- [#539](https://github.com/mobilityhouse/ocpp/issues/539) feat: Add ChargePoint._handle_call return value. Thanks [@wafa-yah](https://github.com/wafa-yah)
+- [#266](https://github.com/mobilityhouse/ocpp/issues/266) fix: Central System documentation link.
+- [#516](https://github.com/mobilityhouse/ocpp/issues/516) OCPP 2.0.1 add additional security events from v1.3.
+- [#537](https://github.com/mobilityhouse/ocpp/pull/537) Fix DataTransfer data types. Thanks [@mdwcrft](https://github.com/mdwcrft)
 
 ## 0.23.0 (2023-11-30)
 
@@ -13,7 +13,6 @@
 - [#528](https://github.com/mobilityhouse/ocpp/issues/528) v2.0.1 CertificateHashDataChainType childCertificateHashData requires the default of None.
 - [#510](https://github.com/mobilityhouse/ocpp/issues/510) v2.0.1 UnitOfMeasureType - Enums missing and update docstring to allow use for variableCharacteristics.
 - [#508](https://github.com/mobilityhouse/ocpp/issues/508) Exception - OccurrenceConstraintViolationError doc string correction.
-
 
 ## 0.22.0 (2023-11-03)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = "2023, Auke Willem Oosterhoff"
 author = "Auke Willem Oosterhoff"
 
 # The full version, including alpha/beta/rc tags
-release = "0.23.0"
+release = "0.24.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocpp"
-version = "0.23.0"
+version = "0.24.0"
 description = "Python package implementing the JSON version of the Open Charge Point Protocol (OCPP)."
 authors = [
 	"André Duarte <andre15x@gmail.com>",


### PR DESCRIPTION
#539 feat: Add ChargePoint._handle_call return value. Thanks [@wafa-yah](https://github.com/wafa-yah)
#266 fix: Central System documentation link.
#516 OCPP 2.0.1 add additional security events from v1.3.
#537 Fix DataTransfer data types. Thanks [@mdwcrft](https://github.com/mdwcrft)