### PR TITLE
Bump to 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+## 0.25.0 (2023-12-22)
+
 - [#554](https://github.com/mobilityhouse/ocpp/issues/554) OCPP 2.0.1 Edition 2 Errata 2023-12 document added
 - [#548](https://github.com/mobilityhouse/ocpp/issues/548) OCPP 2.0.1 MessageInfoType attribute name correction
 - [#300](https://github.com/mobilityhouse/ocpp/issues/300) OCPP 2.0.1 add reference components and variables

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = "2023, Auke Willem Oosterhoff"
 author = "Auke Willem Oosterhoff"
 
 # The full version, including alpha/beta/rc tags
-release = "0.24.0"
+release = "0.25.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocpp"
-version = "0.24.0"
+version = "0.25.0"
 description = "Python package implementing the JSON version of the Open Charge Point Protocol (OCPP)."
 authors = [
 	"André Duarte <andre15x@gmail.com>",


### PR DESCRIPTION
#554 OCPP 2.0.1 Edition 2 Errata 2023-12 document added
#548 OCPP 2.0.1 MessageInfoType attribute name correction
#300 OCPP 2.0.1 add reference components and variables
#518 OCPP 2.0.1 add additional reason codes from v1.3