### PR TITLE
v201:call,call_result,datatypes: complete and corrected type annotations

### DIFF
--- a/ocpp/v201/call.py
+++ b/ocpp/v201/call.py
@@ -2,19 +2,21 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ocpp.v201 import enums
+from ocpp.v201 import datatypes
 
 @dataclass
 class Authorize:
-    id_token: Dict
+    id_token: datatypes.IdTokenType
     certificate: Optional[str] = None
-    iso15118_certificate_hash_data: Optional[List] = None
+    iso15118_certificate_hash_data: Optional[List[datatypes.OCSPRequestDataType]] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class BootNotification:
-    charging_station: Dict
-    reason: str
+    charging_station: datatypes.ChargingStationType
+    reason: enums.BootReasonType
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -27,14 +29,14 @@ class CancelReservation:
 @dataclass
 class CertificateSigned:
     certificate_chain: str
-    certificate_type: Optional[str] = None
+    certificate_type: Optional[enums.CertificateSigningUseType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ChangeAvailability:
-    operational_status: str
-    evse: Optional[Dict] = None
+    operational_status: enums.OperationalStatusType
+    evse: Optional[datatypes.EVSEType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -46,7 +48,7 @@ class ClearCache:
 @dataclass
 class ClearChargingProfile:
     charging_profile_id: Optional[int] = None
-    charging_profile_criteria: Optional[Dict] = None
+    charging_profile_criteria: Optional[datatypes.ClearChargingProfileType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -58,13 +60,13 @@ class ClearDisplayMessage:
 
 @dataclass
 class ClearVariableMonitoring:
-    id: List
+    id: List[int]
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ClearedChargingLimit:
-    charging_limit_source: str
+    charging_limit_source: enums.ChargingLimitSourceType
     evse_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -81,8 +83,8 @@ class CustomerInformation:
     request_id: int
     report: bool
     clear: bool
-    customer_certificate: Optional[Dict] = None
-    id_token: Optional[Dict] = None
+    customer_certificate: Optional[datatypes.CertificateHashDataType] = None
+    id_token: Optional[datatypes.IdTokenType] = None
     customer_identifier: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -97,13 +99,13 @@ class DataTransfer:
 
 @dataclass
 class DeleteCertificate:
-    certificate_hash_data: Dict
+    certificate_hash_data: datatypes.CertificateHashDataType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class FirmwareStatusNotification:
-    status: str
+    status: enums.FirmwareStatusType
     request_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -111,7 +113,7 @@ class FirmwareStatusNotification:
 @dataclass
 class Get15118EVCertificate:
     iso15118_schema_version: str
-    action: str
+    action: enums.CertificateActionType
     exi_request: str
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -119,20 +121,20 @@ class Get15118EVCertificate:
 @dataclass
 class GetBaseReport:
     request_id: int
-    report_base: str
+    report_base: enums.ReportBaseType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetCertificateStatus:
-    ocsp_request_data: Dict
+    ocsp_request_data: datatypes.OCSPRequestDataType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetChargingProfiles:
     request_id: int
-    charging_profile: Dict
+    charging_profile: datatypes.ChargingProfileCriterionType
     evse_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -141,22 +143,22 @@ class GetChargingProfiles:
 class GetCompositeSchedule:
     duration: int
     evse_id: int
-    charging_rate_unit: Optional[str] = None
+    charging_rate_unit: Optional[enums.ChargingRateUnitType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetDisplayMessages:
     request_id: int
-    id: Optional[List] = None
-    priority: Optional[str] = None
-    state: Optional[str] = None
+    id: Optional[List[int]] = None
+    priority: Optional[enums.MessagePriorityType] = None
+    state: Optional[enums.MessageStateType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetInstalledCertificateIds:
-    certificate_type: Optional[List] = None
+    certificate_type: Optional[List[enums.GetCertificateIdUseType]] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -167,8 +169,8 @@ class GetLocalListVersion:
 
 @dataclass
 class GetLog:
-    log: Dict
-    log_type: str
+    log: datatypes.LogParametersType
+    log_type: enums.LogType
     request_id: int
     retries: Optional[int] = None
     retry_interval: Optional[int] = None
@@ -178,16 +180,16 @@ class GetLog:
 @dataclass
 class GetMonitoringReport:
     request_id: int
-    component_variable: Optional[List] = None
-    monitoring_criteria: Optional[List] = None
+    component_variable: Optional[List[datatypes.ComponentVariableType]] = None
+    monitoring_criteria: Optional[List[enums.MonitoringCriterionType]] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetReport:
     request_id: int
-    component_variable: Optional[List] = None
-    component_criteria: Optional[List] = None
+    component_variable: Optional[List[datatypes.ComponentVariableType]] = None
+    component_criteria: Optional[List[enums.ComponentCriterionType]] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -199,7 +201,7 @@ class GetTransactionStatus:
 
 @dataclass
 class GetVariables:
-    get_variable_data: List
+    get_variable_data: List[datatypes.GetVariableDataType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -210,14 +212,14 @@ class Heartbeat:
 
 @dataclass
 class InstallCertificate:
-    certificate_type: str
+    certificate_type: enums.InstallCertificateUseType
     certificate: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class LogStatusNotification:
-    status: str
+    status: enums.UploadLogStatusType
     request_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -225,14 +227,14 @@ class LogStatusNotification:
 @dataclass
 class MeterValues:
     evse_id: int
-    meter_value: List
+    meter_value: List[datatypes.MeterValueType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class NotifyChargingLimit:
-    charging_limit: Dict
-    charging_schedule: Optional[List] = None
+    charging_limit: datatypes.ChargingLimitType
+    charging_schedule: Optional[List[datatypes.ChargingScheduleType]] = None
     evse_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -250,14 +252,14 @@ class NotifyCustomerInformation:
 @dataclass
 class NotifyDisplayMessages:
     request_id: int
-    message_info: Optional[List] = None
+    message_info: Optional[List[datatypes.MessageInfoType]] = None
     tbc: Optional[bool] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class NotifyEVChargingNeeds:
-    charging_needs: Dict
+    charging_needs: datatypes.ChargingNeedsType
     evse_id: int
     max_schedule_tuples: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
@@ -266,7 +268,7 @@ class NotifyEVChargingNeeds:
 @dataclass
 class NotifyEVChargingSchedule:
     time_base: str
-    charging_schedule: Dict
+    charging_schedule: datatypes.ChargingScheduleType
     evse_id: int
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -275,7 +277,7 @@ class NotifyEVChargingSchedule:
 class NotifyEvent:
     generated_at: str
     seq_no: int
-    event_data: List
+    event_data: List[datatypes.EventDataType]
     tbc: Optional[bool] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -285,7 +287,7 @@ class NotifyMonitoringReport:
     request_id: int
     seq_no: int
     generated_at: str
-    monitor: Optional[List] = None
+    monitor: Optional[List[datatypes.MonitoringDataType]] = None
     tbc: Optional[bool] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -295,7 +297,7 @@ class NotifyReport:
     request_id: int
     generated_at: str
     seq_no: int
-    report_data: Optional[List] = None
+    report_data: Optional[List[datatypes.ReportDataType]] = None
     tbc: Optional[bool] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -312,8 +314,8 @@ class PublishFirmware:
 
 @dataclass
 class PublishFirmwareStatusNotification:
-    status: str
-    location: Optional[List] = None
+    status: enums.PublishFirmwareStatusType
+    location: Optional[List[str]] = None
     request_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -321,8 +323,8 @@ class PublishFirmwareStatusNotification:
 @dataclass
 class ReportChargingProfiles:
     request_id: int
-    charging_limit_source: str
-    charging_profile: List
+    charging_limit_source: enums.ChargingLimitSourceType
+    charging_profile: List[datatypes.ChargingProfileType]
     evse_id: int
     tbc: Optional[bool] = None
     custom_data: Optional[Dict[str, Any]] = None
@@ -330,11 +332,11 @@ class ReportChargingProfiles:
 
 @dataclass
 class RequestStartTransaction:
-    id_token: Dict
+    id_token: datatypes.IdTokenType
     remote_start_id: int
     evse_id: Optional[int] = None
-    group_id_token: Optional[Dict] = None
-    charging_profile: Optional[Dict] = None
+    group_id_token: Optional[datatypes.IdTokenType] = None
+    charging_profile: Optional[datatypes.ChargingProfileType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -347,7 +349,7 @@ class RequestStopTransaction:
 @dataclass
 class ReservationStatusUpdate:
     reservation_id: int
-    reservation_update_status: str
+    reservation_update_status: enums.ReservationUpdateStatusType
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -355,16 +357,16 @@ class ReservationStatusUpdate:
 class ReserveNow:
     id: int
     expiry_date_time: str
-    id_token: Dict
-    connector_type: Optional[str] = None
+    id_token: datatypes.IdTokenType
+    connector_type: Optional[enums.ConnectorType] = None
     evse_id: Optional[int] = None
-    group_id_token: Optional[Dict] = None
+    group_id_token: Optional[datatypes.IdTokenType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class Reset:
-    type: str
+    type: enums.ResetType
     evse_id: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None
 
@@ -380,27 +382,27 @@ class SecurityEventNotification:
 @dataclass
 class SendLocalList:
     version_number: int
-    update_type: str
-    local_authorization_list: Optional[List] = None
+    update_type: enums.UpdateType
+    local_authorization_list: Optional[List[datatypes.AuthorizationData]] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetChargingProfile:
     evse_id: int
-    charging_profile: Dict
+    charging_profile: datatypes.ChargingProfileType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetDisplayMessage:
-    message: Dict
+    message: datatypes.MessageInfoType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetMonitoringBase:
-    monitoring_base: str
+    monitoring_base: enums.MonitorBaseType
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -413,33 +415,33 @@ class SetMonitoringLevel:
 @dataclass
 class SetNetworkProfile:
     configuration_slot: int
-    connection_data: Dict
+    connection_data: datatypes.NetworkConnectionProfileType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetVariableMonitoring:
-    set_monitoring_data: List
+    set_monitoring_data: List[datatypes.SetMonitoringDataType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetVariables:
-    set_variable_data: List
+    set_variable_data: List[datatypes.SetVariableDataType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SignCertificate:
     csr: str
-    certificate_type: Optional[str] = None
+    certificate_type: Optional[enums.CertificateSigningUseType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class StatusNotification:
     timestamp: str
-    connector_status: str
+    connector_status: enums.ConnectorStatusType
     evse_id: int
     connector_id: int
     custom_data: Optional[Dict[str, Any]] = None
@@ -447,25 +449,25 @@ class StatusNotification:
 
 @dataclass
 class TransactionEvent:
-    event_type: str
+    event_type: enums.TransactionEventType
     timestamp: str
-    trigger_reason: str
+    trigger_reason: enums.TriggerReasonType
     seq_no: int
-    transaction_info: Dict
-    meter_value: Optional[List] = None
+    transaction_info: datatypes.TransactionType
+    meter_value: Optional[List[datatypes.MeterValueType]] = None
     offline: Optional[bool] = None
     number_of_phases_used: Optional[int] = None
     cable_max_current: Optional[int] = None
     reservation_id: Optional[int] = None
-    evse: Optional[Dict] = None
-    id_token: Optional[Dict] = None
+    evse: Optional[datatypes.EVSEType] = None
+    id_token: Optional[datatypes.IdTokenType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class TriggerMessage:
-    requested_message: str
-    evse: Optional[Dict] = None
+    requested_message: enums.MessageTriggerType
+    evse: Optional[datatypes.EVSEType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -485,7 +487,7 @@ class UnpublishFirmware:
 @dataclass
 class UpdateFirmware:
     request_id: int
-    firmware: Dict
+    firmware: datatypes.FirmwareType
     retries: Optional[int] = None
     retry_interval: Optional[int] = None
     custom_data: Optional[Dict[str, Any]] = None

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -2,11 +2,13 @@ import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from ocpp.v201 import enums
+from ocpp.v201 import datatypes
 
 @dataclass
 class Authorize:
-    id_token_info: Dict
-    certificate_status: Optional[str] = None
+    id_token_info: datatypes.IdTokenInfoType
+    certificate_status: Optional[enums.AuthorizeCertificateStatusType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -14,56 +16,56 @@ class Authorize:
 class BootNotification:
     current_time: str
     interval: int
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.RegistrationStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class CancelReservation:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.CancelReservationStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class CertificateSigned:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.CertificateSignedStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ChangeAvailability:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ChangeAvailabilityStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ClearCache:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ClearCacheStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ClearChargingProfile:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ClearChargingProfileStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ClearDisplayMessage:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ClearMessageStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class ClearVariableMonitoring:
-    clear_monitoring_result: List
+    clear_monitoring_result: List[enums.ClearMonitoringStatusType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -79,23 +81,23 @@ class CostUpdated:
 
 @dataclass
 class CustomerInformation:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.CustomerInformationStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class DataTransfer:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.DataTransferStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     data: Optional[Any] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class DeleteCertificate:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.DeleteCertificateStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -106,54 +108,54 @@ class FirmwareStatusNotification:
 
 @dataclass
 class Get15118EVCertificate:
-    status: str
+    status: enums.Iso15118EVCertificateStatusType
     exi_response: str
-    status_info: Optional[Dict] = None
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetBaseReport:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericDeviceModelStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetCertificateStatus:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GetCertificateStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     ocsp_result: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetChargingProfiles:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GetChargingProfileStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetCompositeSchedule:
-    status: str
-    status_info: Optional[Dict] = None
-    schedule: Optional[Dict] = None
+    status: enums.GenericStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
+    schedule: Optional[datatypes.CompositeScheduleType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetDisplayMessages:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GetDisplayMessagesStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetInstalledCertificateIds:
-    status: str
-    status_info: Optional[Dict] = None
-    certificate_hash_data_chain: Optional[List] = None
+    status: enums.GetInstalledCertificateStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
+    certificate_hash_data_chain: Optional[List[datatypes.CertificateHashDataChainType]] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -165,23 +167,23 @@ class GetLocalListVersion:
 
 @dataclass
 class GetLog:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.LogStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     filename: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetMonitoringReport:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericDeviceModelStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class GetReport:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericDeviceModelStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -194,7 +196,7 @@ class GetTransactionStatus:
 
 @dataclass
 class GetVariables:
-    get_variable_result: List
+    get_variable_result: List[datatypes.GetVariableResultType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -206,8 +208,8 @@ class Heartbeat:
 
 @dataclass
 class InstallCertificate:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.InstallCertificateStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -238,15 +240,15 @@ class NotifyDisplayMessages:
 
 @dataclass
 class NotifyEVChargingNeeds:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.NotifyEVChargingNeedsStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class NotifyEVChargingSchedule:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -267,8 +269,8 @@ class NotifyReport:
 
 @dataclass
 class PublishFirmware:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.PublishFirmwareStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -284,16 +286,16 @@ class ReportChargingProfiles:
 
 @dataclass
 class RequestStartTransaction:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.RequestStartStopStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     transaction_id: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class RequestStopTransaction:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.RequestStartStopStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -304,15 +306,15 @@ class ReservationStatusUpdate:
 
 @dataclass
 class ReserveNow:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ReserveNowStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class Reset:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ResetStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -323,62 +325,62 @@ class SecurityEventNotification:
 
 @dataclass
 class SendLocalList:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.SendLocalListStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetChargingProfile:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.ChargingProfileStatus
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetDisplayMessage:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.DisplayMessageStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetMonitoringBase:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetMonitoringLevel:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetNetworkProfile:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.SetNetworkProfileStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetVariableMonitoring:
-    set_monitoring_result: List
+    set_monitoring_result: List[datatypes.SetMonitoringResultType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SetVariables:
-    set_variable_result: List
+    set_variable_result: List[datatypes.SetVariableResultType]
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class SignCertificate:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.GenericStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
@@ -391,35 +393,35 @@ class StatusNotification:
 class TransactionEvent:
     total_cost: Optional[float] = None
     charging_priority: Optional[int] = None
-    id_token_info: Optional[Dict] = None
-    updated_personal_message: Optional[Dict] = None
+    id_token_info: Optional[datatypes.IdTokenInfoType] = None
+    updated_personal_message: Optional[datatypes.MessageContentType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class TriggerMessage:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.TriggerMessageStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class UnlockConnector:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.UnlockStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class UnpublishFirmware:
-    status: str
+    status: enums.UnpublishFirmwareStatusType
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
 class UpdateFirmware:
-    status: str
-    status_info: Optional[Dict] = None
+    status: enums.FirmwareStatusType
+    status_info: Optional[datatypes.StatusInfoType] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 

--- a/ocpp/v201/datatypes.py
+++ b/ocpp/v201/datatypes.py
@@ -555,7 +555,7 @@ class UnitOfMeasureType:
     UnitOfMeasureType is used by: SampledValueType
     """
 
-    unit: Optional[str] = None
+    unit: Optional[enums.UnitOfMeasureType] = None
     multiplier: Optional[int] = None
 
 


### PR DESCRIPTION
I groveled through the v2.0.1 spec and updated all of the type signatures to be complete and accurate to the best of my ability.

I did this to support some work I'm doing to make a variant of `@on` that converts the JSON back to Python objects, but I think it will be useful to anyone using the library with an IDE, so I'm submitting it as a separate pull request.