### PR TITLE
Revert changes made in pr #537 to change DataTransfer.data typehint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#548](https://github.com/mobilityhouse/ocpp/issues/548) OCPP 2.0.1 MessageInfoType attribute name correction
 - [#300](https://github.com/mobilityhouse/ocpp/issues/300) OCPP 2.0.1 add reference components and variables
 - [#518](https://github.com/mobilityhouse/ocpp/issues/518) OCPP 2.0.1 add additional reason codes from v1.3
+- [#569](https://github.com/mobilityhouse/ocpp/issues/569) Revert DataTransfer.data type hint
 
 ## 0.24.0 (2023-12-07)
 

--- a/ocpp/v201/call.py
+++ b/ocpp/v201/call.py
@@ -90,7 +90,7 @@ class CustomerInformationPayload:
 class DataTransferPayload:
     vendor_id: str
     message_id: Optional[str] = None
-    data: Optional[Any] = None
+    data: Optional[Dict] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -87,7 +87,7 @@ class CustomerInformationPayload:
 class DataTransferPayload:
     status: str
     status_info: Optional[Dict] = None
-    data: Optional[str] = None
+    data: Optional[str] = None  # OCPP 2.0.1 Edition 2 specifies `AnyType` as text.
     custom_data: Optional[Dict[str, Any]] = None
 
 

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -87,7 +87,7 @@ class CustomerInformationPayload:
 class DataTransferPayload:
     status: str
     status_info: Optional[Dict] = None
-    data: Optional[Any] = None
+    data: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 


### PR DESCRIPTION
According to this [issue](https://github.com/mobilityhouse/ocpp/issues/569), a PR was made to change the type of `DataTransfer.data` to `Any` rather than `str`.

This PR makes the type `str` instead of `Any`.