### PR TITLE
Update ChangeConfiguration.json

### DIFF
--- a/ocpp/v16/schemas/ChangeConfiguration.json
+++ b/ocpp/v16/schemas/ChangeConfiguration.json
@@ -8,7 +8,7 @@
             "maxLength": 50
         },
         "value": {
-            "type": "string",
+            "type": ["string","number","boolean","integer"],
             "maxLength": 500
         }
     },


### PR DESCRIPTION
Dear project owner,
Actually we have found that in the real world case, certain provider, for example Scame from Italy, configure the charger in such a way that the value of configuration could be a string, a number or a boolean. For example, the hearbeat interval or metervalues interval is of a type of integer. That is why we sincerely proposed this change because otherwise the request sent to the charger will trigger some error.  Thanks
Yong