### PR TITLE
Update GetConfigurationResponse.json

### DIFF
--- a/ocpp/v16/schemas/GetConfigurationResponse.json
+++ b/ocpp/v16/schemas/GetConfigurationResponse.json
@@ -16,7 +16,7 @@
                         "type": "boolean"
                     },
                     "value": {
-                        "type": "string",
+                        "type": ["integer", "string", "boolean", "number"],
                         "maxLength": 500
                     }
                 },


### PR DESCRIPTION
Dear project owner,
Actually we have found that in the real world case, certain provider, for example Scame from Italy, configure the charger in such a way that the value of configuration could be a string, a number or a boolean. For example, the hearbeat interval or metervalues interval is of a type of integer. 

The same as change configuration, we sincerely proposed this change because otherwise the response that we get from the charger will trigger some error. Thanks

Yong