### PR TITLE
OCPP v1.6/v2.0.1 deprecate dataclasses from calls and call results with the suffix 'Payload'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- [#583](https://github.com/mobilityhouse/ocpp/issues/583) OCPP v1.6/v2.0.1 deprecate dataclasses from calls and call results with the suffix 'Payload'
+
 ## 0.26.0 (2024-01-17)
 
 - [#544](https://github.com/mobilityhouse/ocpp/issues/544) ocpp/charge_point.py - Pass `Call.unique_id` to the `on` and `after` routing handlers.

--- a/ocpp/v16/call.py
+++ b/ocpp/v16/call.py
@@ -308,199 +308,325 @@ class DataTransfer:
 @dataclass
 class CancelReservationPayload(CancelReservation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " + __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload(CertificateSigned):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload(ChangeAvailability):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeConfigurationPayload(ChangeConfiguration):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload(ClearCache):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload(ClearChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload(DeleteCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ExtendedTriggerMessagePayload(ExtendedTriggerMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload(GetCompositeSchedule):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetConfigurationPayload(GetConfiguration):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDiagnosticsPayload(GetDiagnostics):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload(GetLocalListVersion):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload(GetLog):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload(InstallCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStartTransactionPayload(RemoteStartTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStopTransactionPayload(RemoteStopTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload(ReserveNow):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload(Reset):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload(SendLocalList):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload(SetChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedUpdateFirmwarePayload(SignedUpdateFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload(TriggerMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload(UnlockConnector):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload(UpdateFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # The CALL messages that flow from Charge Point to Central System are listed
@@ -511,103 +637,169 @@ class UpdateFirmwarePayload(UpdateFirmware):
 @dataclass
 class AuthorizePayload(Authorize):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload(BootNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DiagnosticsStatusNotificationPayload(DiagnosticsStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload(Heartbeat):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload(LogStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload(MeterValues):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload(SecurityEventNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload(SignCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
+
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedFirmwareStatusNotificationPayload(SignedFirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StartTransactionPayload(StartTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StopTransactionPayload(StopTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload(StatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # The DataTransfer CALL can be send both from Central System as well as from a
@@ -618,5 +810,10 @@ class StatusNotificationPayload(StatusNotification):
 @dataclass
 class DataTransferPayload(DataTransfer):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )

--- a/ocpp/v16/call.py
+++ b/ocpp/v16/call.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
@@ -305,185 +306,201 @@ class DataTransfer:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CancelReservationPayload:
-    reservation_id: int
+class CancelReservationPayload(CancelReservation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " + __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CertificateSignedPayload:
-    certificate_chain: str
+class CertificateSignedPayload(CertificateSigned):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ChangeAvailabilityPayload:
-    connector_id: int
-    type: AvailabilityType
+class ChangeAvailabilityPayload(ChangeAvailability):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ChangeConfigurationPayload:
-    key: str
-    value: str
+class ChangeConfigurationPayload(ChangeConfiguration):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearCachePayload:
-    pass
+class ClearCachePayload(ClearCache):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearChargingProfilePayload:
-    id: Optional[int] = None
-    connector_id: Optional[int] = None
-    charging_profile_purpose: Optional[ChargingProfilePurposeType] = None
-    stack_level: Optional[int] = None
+class ClearChargingProfilePayload(ClearChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DeleteCertificatePayload:
-    certificate_hash_data: Dict
+class DeleteCertificatePayload(DeleteCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ExtendedTriggerMessagePayload:
-    requested_message: MessageTrigger
-    connector_id: Optional[int] = None
+class ExtendedTriggerMessagePayload(ExtendedTriggerMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetCompositeSchedulePayload:
-    connector_id: int
-    duration: int
-    charging_rate_unit: Optional[ChargingRateUnitType] = None
+class GetCompositeSchedulePayload(GetCompositeSchedule):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetConfigurationPayload:
-    key: Optional[List] = None
+class GetConfigurationPayload(GetConfiguration):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetDiagnosticsPayload:
-    location: str
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
-    start_time: Optional[str] = None
-    stop_time: Optional[str] = None
+class GetDiagnosticsPayload(GetDiagnostics):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetInstalledCertificateIdsPayload:
-    certificate_type: CertificateUse
+class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLocalListVersionPayload:
-    pass
+class GetLocalListVersionPayload(GetLocalListVersion):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLogPayload:
-    log: Dict
-    log_type: Log
-    request_id: int
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
+class GetLogPayload(GetLog):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class InstallCertificatePayload:
-    certificate_type: CertificateUse
-    certificate: str
+class InstallCertificatePayload(InstallCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RemoteStartTransactionPayload:
-    id_tag: str
-    connector_id: Optional[int] = None
-    charging_profile: Optional[Dict] = None
+class RemoteStartTransactionPayload(RemoteStartTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RemoteStopTransactionPayload:
-    transaction_id: int
+class RemoteStopTransactionPayload(RemoteStopTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReserveNowPayload:
-    connector_id: int
-    expiry_date: str
-    id_tag: str
-    reservation_id: int
-    parent_id_tag: Optional[str] = None
+class ReserveNowPayload(ReserveNow):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ResetPayload:
-    type: ResetType
+class ResetPayload(Reset):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SendLocalListPayload:
-    list_version: int
-    update_type: UpdateType
-    local_authorization_list: List = field(default_factory=list)
+class SendLocalListPayload(SendLocalList):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetChargingProfilePayload:
-    connector_id: int
-    cs_charging_profiles: Dict
+class SetChargingProfilePayload(SetChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignedUpdateFirmwarePayload:
-    request_id: int
-    firmware: Dict
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
+class SignedUpdateFirmwarePayload(SignedUpdateFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class TriggerMessagePayload:
-    requested_message: MessageTrigger
-    connector_id: Optional[int] = None
+class TriggerMessagePayload(TriggerMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UnlockConnectorPayload:
-    connector_id: int
+class UnlockConnectorPayload(UnlockConnector):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UpdateFirmwarePayload:
-    location: str
-    retrieve_date: str
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
+class UpdateFirmwarePayload(UpdateFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # The CALL messages that flow from Charge Point to Central System are listed
@@ -492,109 +509,105 @@ class UpdateFirmwarePayload:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class AuthorizePayload:
-    id_tag: str
+class AuthorizePayload(Authorize):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class BootNotificationPayload:
-    charge_point_model: str
-    charge_point_vendor: str
-    charge_box_serial_number: Optional[str] = None
-    charge_point_serial_number: Optional[str] = None
-    firmware_version: Optional[str] = None
-    iccid: Optional[str] = None
-    imsi: Optional[str] = None
-    meter_serial_number: Optional[str] = None
-    meter_type: Optional[str] = None
+class BootNotificationPayload(BootNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DiagnosticsStatusNotificationPayload:
-    status: DiagnosticsStatus
+class DiagnosticsStatusNotificationPayload(DiagnosticsStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class FirmwareStatusNotificationPayload:
-    status: FirmwareStatus
+class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class HeartbeatPayload:
-    pass
+class HeartbeatPayload(Heartbeat):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class LogStatusNotificationPayload:
-    status: UploadLogStatus
-    request_id: int
+class LogStatusNotificationPayload(LogStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class MeterValuesPayload:
-    connector_id: int
-    meter_value: List = field(default_factory=list)
-    transaction_id: Optional[int] = None
+class MeterValuesPayload(MeterValues):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SecurityEventNotificationPayload:
-    type: str
-    timestamp: str
-    tech_info: Optional[str]
+class SecurityEventNotificationPayload(SecurityEventNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignCertificatePayload:
-    csr: str
+class SignCertificatePayload(SignCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
+class SignedFirmwareStatusNotificationPayload(SignedFirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignedFirmwareStatusNotificationPayload:
-    status: FirmwareStatus
-    request_id: int
+class StartTransactionPayload(StartTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StartTransactionPayload:
-    connector_id: int
-    id_tag: str
-    meter_start: int
-    timestamp: str
-    reservation_id: Optional[int] = None
+class StopTransactionPayload(StopTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StopTransactionPayload:
-    meter_stop: int
-    timestamp: str
-    transaction_id: int
-    reason: Optional[Reason] = None
-    id_tag: Optional[str] = None
-    transaction_data: Optional[List] = None
-
-
-# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
-@dataclass
-class StatusNotificationPayload:
-    connector_id: int
-    error_code: ChargePointErrorCode
-    status: ChargePointStatus
-    timestamp: Optional[str] = None
-    info: Optional[str] = None
-    vendor_id: Optional[str] = None
-    vendor_error_code: Optional[str] = None
+class StatusNotificationPayload(StatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # The DataTransfer CALL can be send both from Central System as well as from a
@@ -603,7 +616,7 @@ class StatusNotificationPayload:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DataTransferPayload:
-    vendor_id: str
-    message_id: Optional[str] = None
-    data: Optional[str] = None
+class DataTransferPayload(DataTransfer):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))

--- a/ocpp/v16/call.py
+++ b/ocpp/v16/call.py
@@ -37,32 +37,305 @@ from ocpp.v16.enums import (
 
 
 @dataclass
+class CancelReservation:
+    reservation_id: int
+
+
+@dataclass
+class CertificateSigned:
+    certificate_chain: str
+
+
+@dataclass
+class ChangeAvailability:
+    connector_id: int
+    type: AvailabilityType
+
+
+@dataclass
+class ChangeConfiguration:
+    key: str
+    value: str
+
+
+@dataclass
+class ClearCache:
+    pass
+
+
+@dataclass
+class ClearChargingProfile:
+    id: Optional[int] = None
+    connector_id: Optional[int] = None
+    charging_profile_purpose: Optional[ChargingProfilePurposeType] = None
+    stack_level: Optional[int] = None
+
+
+@dataclass
+class DeleteCertificate:
+    certificate_hash_data: Dict
+
+
+@dataclass
+class ExtendedTriggerMessage:
+    requested_message: MessageTrigger
+    connector_id: Optional[int] = None
+
+
+@dataclass
+class GetCompositeSchedule:
+    connector_id: int
+    duration: int
+    charging_rate_unit: Optional[ChargingRateUnitType] = None
+
+
+@dataclass
+class GetConfiguration:
+    key: Optional[List] = None
+
+
+@dataclass
+class GetDiagnostics:
+    location: str
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+    start_time: Optional[str] = None
+    stop_time: Optional[str] = None
+
+
+@dataclass
+class GetInstalledCertificateIds:
+    certificate_type: CertificateUse
+
+
+@dataclass
+class GetLocalListVersion:
+    pass
+
+
+@dataclass
+class GetLog:
+    log: Dict
+    log_type: Log
+    request_id: int
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+
+
+@dataclass
+class InstallCertificate:
+    certificate_type: CertificateUse
+    certificate: str
+
+
+@dataclass
+class RemoteStartTransaction:
+    id_tag: str
+    connector_id: Optional[int] = None
+    charging_profile: Optional[Dict] = None
+
+
+@dataclass
+class RemoteStopTransaction:
+    transaction_id: int
+
+
+@dataclass
+class ReserveNow:
+    connector_id: int
+    expiry_date: str
+    id_tag: str
+    reservation_id: int
+    parent_id_tag: Optional[str] = None
+
+
+@dataclass
+class Reset:
+    type: ResetType
+
+
+@dataclass
+class SendLocalList:
+    list_version: int
+    update_type: UpdateType
+    local_authorization_list: List = field(default_factory=list)
+
+
+@dataclass
+class SetChargingProfile:
+    connector_id: int
+    cs_charging_profiles: Dict
+
+
+@dataclass
+class SignedUpdateFirmware:
+    request_id: int
+    firmware: Dict
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+
+
+@dataclass
+class TriggerMessage:
+    requested_message: MessageTrigger
+    connector_id: Optional[int] = None
+
+
+@dataclass
+class UnlockConnector:
+    connector_id: int
+
+
+@dataclass
+class UpdateFirmware:
+    location: str
+    retrieve_date: str
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+
+
+# The CALL messages that flow from Charge Point to Central System are listed
+# in the bottom part of this module.
+
+
+@dataclass
+class Authorize:
+    id_tag: str
+
+
+@dataclass
+class BootNotification:
+    charge_point_model: str
+    charge_point_vendor: str
+    charge_box_serial_number: Optional[str] = None
+    charge_point_serial_number: Optional[str] = None
+    firmware_version: Optional[str] = None
+    iccid: Optional[str] = None
+    imsi: Optional[str] = None
+    meter_serial_number: Optional[str] = None
+    meter_type: Optional[str] = None
+
+
+@dataclass
+class DiagnosticsStatusNotification:
+    status: DiagnosticsStatus
+
+
+@dataclass
+class FirmwareStatusNotification:
+    status: FirmwareStatus
+
+
+@dataclass
+class Heartbeat:
+    pass
+
+
+@dataclass
+class LogStatusNotification:
+    status: UploadLogStatus
+    request_id: int
+
+
+@dataclass
+class MeterValues:
+    connector_id: int
+    meter_value: List = field(default_factory=list)
+    transaction_id: Optional[int] = None
+
+
+@dataclass
+class SecurityEventNotification:
+    type: str
+    timestamp: str
+    tech_info: Optional[str]
+
+
+@dataclass
+class SignCertificate:
+    csr: str
+
+
+@dataclass
+class SignedFirmwareStatusNotification:
+    status: FirmwareStatus
+    request_id: int
+
+
+@dataclass
+class StartTransaction:
+    connector_id: int
+    id_tag: str
+    meter_start: int
+    timestamp: str
+    reservation_id: Optional[int] = None
+
+
+@dataclass
+class StopTransaction:
+    meter_stop: int
+    timestamp: str
+    transaction_id: int
+    reason: Optional[Reason] = None
+    id_tag: Optional[str] = None
+    transaction_data: Optional[List] = None
+
+
+@dataclass
+class StatusNotification:
+    connector_id: int
+    error_code: ChargePointErrorCode
+    status: ChargePointStatus
+    timestamp: Optional[str] = None
+    info: Optional[str] = None
+    vendor_id: Optional[str] = None
+    vendor_error_code: Optional[str] = None
+
+
+# The DataTransfer CALL can be sent both from Central System as well as from a
+# Charge Point.
+
+
+@dataclass
+class DataTransfer:
+    vendor_id: str
+    message_id: Optional[str] = None
+    data: Optional[str] = None
+
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
 class CancelReservationPayload:
     reservation_id: int
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload:
     certificate_chain: str
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload:
     connector_id: int
     type: AvailabilityType
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeConfigurationPayload:
     key: str
     value: str
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload:
     id: Optional[int] = None
@@ -71,17 +344,20 @@ class ClearChargingProfilePayload:
     stack_level: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload:
     certificate_hash_data: Dict
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ExtendedTriggerMessagePayload:
     requested_message: MessageTrigger
     connector_id: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload:
     connector_id: int
@@ -89,11 +365,13 @@ class GetCompositeSchedulePayload:
     charging_rate_unit: Optional[ChargingRateUnitType] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetConfigurationPayload:
     key: Optional[List] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDiagnosticsPayload:
     location: str
@@ -103,16 +381,19 @@ class GetDiagnosticsPayload:
     stop_time: Optional[str] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload:
     certificate_type: CertificateUse
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload:
     log: Dict
@@ -122,12 +403,14 @@ class GetLogPayload:
     retry_interval: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload:
     certificate_type: CertificateUse
     certificate: str
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStartTransactionPayload:
     id_tag: str
@@ -135,11 +418,13 @@ class RemoteStartTransactionPayload:
     charging_profile: Optional[Dict] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStopTransactionPayload:
     transaction_id: int
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload:
     connector_id: int
@@ -149,11 +434,13 @@ class ReserveNowPayload:
     parent_id_tag: Optional[str] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload:
     type: ResetType
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload:
     list_version: int
@@ -161,12 +448,14 @@ class SendLocalListPayload:
     local_authorization_list: List = field(default_factory=list)
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload:
     connector_id: int
     cs_charging_profiles: Dict
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedUpdateFirmwarePayload:
     request_id: int
@@ -175,17 +464,20 @@ class SignedUpdateFirmwarePayload:
     retry_interval: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload:
     requested_message: MessageTrigger
     connector_id: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload:
     connector_id: int
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload:
     location: str
@@ -198,11 +490,13 @@ class UpdateFirmwarePayload:
 # in the bottom part of this module.
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class AuthorizePayload:
     id_tag: str
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload:
     charge_point_model: str
@@ -216,27 +510,32 @@ class BootNotificationPayload:
     meter_type: Optional[str] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DiagnosticsStatusNotificationPayload:
     status: DiagnosticsStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload:
     status: FirmwareStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload:
     status: UploadLogStatus
     request_id: int
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload:
     connector_id: int
@@ -244,6 +543,7 @@ class MeterValuesPayload:
     transaction_id: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload:
     type: str
@@ -251,17 +551,20 @@ class SecurityEventNotificationPayload:
     tech_info: Optional[str]
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload:
     csr: str
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedFirmwareStatusNotificationPayload:
     status: FirmwareStatus
     request_id: int
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StartTransactionPayload:
     connector_id: int
@@ -271,6 +574,7 @@ class StartTransactionPayload:
     reservation_id: Optional[int] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StopTransactionPayload:
     meter_stop: int
@@ -281,6 +585,7 @@ class StopTransactionPayload:
     transaction_data: Optional[List] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload:
     connector_id: int
@@ -296,6 +601,7 @@ class StatusNotificationPayload:
 # Charge Point.
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DataTransferPayload:
     vendor_id: str

--- a/ocpp/v16/call_result.py
+++ b/ocpp/v16/call_result.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -260,77 +261,98 @@ class DataTransfer:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class AuthorizePayload:
-    id_tag_info: IdTagInfo
+class AuthorizePayload(Authorize):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class BootNotificationPayload:
-    current_time: str
-    interval: int
-    status: RegistrationStatus
+class BootNotificationPayload(BootNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DiagnosticsStatusNotificationPayload:
-    pass
+class DiagnosticsStatusNotificationPayload(DiagnosticsStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class FirmwareStatusNotificationPayload:
-    pass
+class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class HeartbeatPayload:
-    current_time: str
+class HeartbeatPayload(Heartbeat):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class LogStatusNotificationPayload:
-    pass
+class LogStatusNotificationPayload(LogStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SecurityEventNotificationPayload:
-    pass
+class SecurityEventNotificationPayload(SecurityEventNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignCertificatePayload:
-    status: GenericStatus
+class SignCertificatePayload(SignCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class MeterValuesPayload:
-    pass
+class MeterValuesPayload(MeterValues):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StartTransactionPayload:
-    transaction_id: int
-    id_tag_info: IdTagInfo
+class StartTransactionPayload(StartTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StatusNotificationPayload:
-    pass
+class StatusNotificationPayload(StatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StopTransactionPayload:
-    id_tag_info: Optional[IdTagInfo] = None
+class StopTransactionPayload(StopTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # The CALLRESULT messages that flow from Charge Point to Central System are
@@ -339,164 +361,209 @@ class StopTransactionPayload:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CancelReservationPayload:
-    status: CancelReservationStatus
+class CancelReservationPayload(CancelReservation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CertificateSignedPayload:
-    status: CertificateSignedStatus
+class CertificateSignedPayload(CertificateSigned):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ChangeAvailabilityPayload:
-    status: AvailabilityStatus
+class ChangeAvailabilityPayload(ChangeAvailability):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ChangeConfigurationPayload:
-    status: ConfigurationStatus
+class ChangeConfigurationPayload(ChangeConfiguration):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearCachePayload:
-    status: ClearCacheStatus
+class ClearCachePayload(ClearCache):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearChargingProfilePayload:
-    status: ClearChargingProfileStatus
+class ClearChargingProfilePayload(ClearChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DeleteCertificatePayload:
-    status: DeleteCertificateStatus
+class DeleteCertificatePayload(DeleteCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ExtendedTriggerMessagePayload:
-    status: TriggerMessageStatus
+class ExtendedTriggerMessagePayload(ExtendedTriggerMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetInstalledCertificateIdsPayload:
-    status: GetInstalledCertificateStatus
-    certificate_hash_data: Optional[List] = None
+class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetCompositeSchedulePayload:
-    status: GetCompositeScheduleStatus
-    connector_id: Optional[int] = None
-    schedule_start: Optional[str] = None
-    charging_schedule: Optional[Dict] = None
+class GetCompositeSchedulePayload(GetCompositeSchedule):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetConfigurationPayload:
-    configuration_key: Optional[List] = None
-    unknown_key: Optional[List] = None
+class GetConfigurationPayload(GetConfiguration):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetDiagnosticsPayload:
-    file_name: Optional[str] = None
+class GetDiagnosticsPayload(GetDiagnostics):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLocalListVersionPayload:
-    list_version: int
+class GetLocalListVersionPayload(GetLocalListVersion):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLogPayload:
-    status: LogStatus
-    filename: Optional[str] = None
+class GetLogPayload(GetLog):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class InstallCertificatePayload:
-    status: CertificateStatus
+class InstallCertificatePayload(InstallCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
+class RemoteStartTransactionPayload(RemoteStartTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RemoteStartTransactionPayload:
-    status: RemoteStartStopStatus
+class RemoteStopTransactionPayload(RemoteStopTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RemoteStopTransactionPayload:
-    status: RemoteStartStopStatus
+class ReserveNowPayload(ReserveNow):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReserveNowPayload:
-    status: ReservationStatus
+class ResetPayload(Reset):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ResetPayload:
-    status: ResetStatus
+class SendLocalListPayload(SendLocalList):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SendLocalListPayload:
-    status: UpdateStatus
+class SetChargingProfilePayload(SetChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetChargingProfilePayload:
-    status: ChargingProfileStatus
+class SignedFirmwareStatusNotificationPayload(SignedFirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignedFirmwareStatusNotificationPayload:
-    pass
+class SignedUpdateFirmwarePayload(SignedUpdateFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignedUpdateFirmwarePayload:
-    status: UpdateFirmwareStatus
+class TriggerMessagePayload(TriggerMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class TriggerMessagePayload:
-    status: TriggerMessageStatus
+class UnlockConnectorPayload(UnlockConnector):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UnlockConnectorPayload:
-    status: UnlockStatus
-
-
-# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
-@dataclass
-class UpdateFirmwarePayload:
-    pass
+class UpdateFirmwarePayload(UpdateFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # The DataTransfer CALLRESULT can be send both from Central System as well as
@@ -505,6 +572,7 @@ class UpdateFirmwarePayload:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DataTransferPayload:
-    status: DataTransferStatus
-    data: Optional[str] = None
+class DataTransferPayload(DataTransfer):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))

--- a/ocpp/v16/call_result.py
+++ b/ocpp/v16/call_result.py
@@ -46,10 +46,225 @@ from ocpp.v16.enums import (
 
 
 @dataclass
+class Authorize:
+    id_tag_info: IdTagInfo
+
+
+@dataclass
+class BootNotification:
+    current_time: str
+    interval: int
+    status: RegistrationStatus
+
+
+@dataclass
+class DiagnosticsStatusNotification:
+    pass
+
+
+@dataclass
+class FirmwareStatusNotification:
+    pass
+
+
+@dataclass
+class Heartbeat:
+    current_time: str
+
+
+@dataclass
+class LogStatusNotification:
+    pass
+
+
+@dataclass
+class SecurityEventNotification:
+    pass
+
+
+@dataclass
+class SignCertificate:
+    status: GenericStatus
+
+
+@dataclass
+class MeterValues:
+    pass
+
+
+@dataclass
+class StartTransaction:
+    transaction_id: int
+    id_tag_info: IdTagInfo
+
+
+@dataclass
+class StatusNotification:
+    pass
+
+
+@dataclass
+class StopTransaction:
+    id_tag_info: Optional[IdTagInfo] = None
+
+
+# The CALLRESULT messages that flow from Charge Point to Central System are
+# listed in the bottom part of this module.
+
+
+@dataclass
+class CancelReservation:
+    status: CancelReservationStatus
+
+
+@dataclass
+class CertificateSigned:
+    status: CertificateSignedStatus
+
+
+@dataclass
+class ChangeAvailability:
+    status: AvailabilityStatus
+
+
+@dataclass
+class ChangeConfiguration:
+    status: ConfigurationStatus
+
+
+@dataclass
+class ClearCache:
+    status: ClearCacheStatus
+
+
+@dataclass
+class ClearChargingProfile:
+    status: ClearChargingProfileStatus
+
+
+@dataclass
+class DeleteCertificate:
+    status: DeleteCertificateStatus
+
+
+@dataclass
+class ExtendedTriggerMessage:
+    status: TriggerMessageStatus
+
+
+@dataclass
+class GetInstalledCertificateIds:
+    status: GetInstalledCertificateStatus
+    certificate_hash_data: Optional[List] = None
+
+
+@dataclass
+class GetCompositeSchedule:
+    status: GetCompositeScheduleStatus
+    connector_id: Optional[int] = None
+    schedule_start: Optional[str] = None
+    charging_schedule: Optional[Dict] = None
+
+
+@dataclass
+class GetConfiguration:
+    configuration_key: Optional[List] = None
+    unknown_key: Optional[List] = None
+
+
+@dataclass
+class GetDiagnostics:
+    file_name: Optional[str] = None
+
+
+@dataclass
+class GetLocalListVersion:
+    list_version: int
+
+
+@dataclass
+class GetLog:
+    status: LogStatus
+    filename: Optional[str] = None
+
+
+@dataclass
+class InstallCertificate:
+    status: CertificateStatus
+
+
+@dataclass
+class RemoteStartTransaction:
+    status: RemoteStartStopStatus
+
+
+@dataclass
+class RemoteStopTransaction:
+    status: RemoteStartStopStatus
+
+
+@dataclass
+class ReserveNow:
+    status: ReservationStatus
+
+
+@dataclass
+class Reset:
+    status: ResetStatus
+
+
+@dataclass
+class SendLocalList:
+    status: UpdateStatus
+
+
+@dataclass
+class SetChargingProfile:
+    status: ChargingProfileStatus
+
+
+@dataclass
+class SignedFirmwareStatusNotification:
+    pass
+
+
+@dataclass
+class SignedUpdateFirmware:
+    status: UpdateFirmwareStatus
+
+
+@dataclass
+class TriggerMessage:
+    status: TriggerMessageStatus
+
+
+@dataclass
+class UnlockConnector:
+    status: UnlockStatus
+
+
+@dataclass
+class UpdateFirmware:
+    pass
+
+
+# The DataTransfer CALLRESULT can be send both from Central System as well as
+# from a Charge Point.
+
+
+@dataclass
+class DataTransfer:
+    status: DataTransferStatus
+    data: Optional[str] = None
+
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
 class AuthorizePayload:
     id_tag_info: IdTagInfo
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload:
     current_time: str
@@ -57,52 +272,62 @@ class BootNotificationPayload:
     status: RegistrationStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DiagnosticsStatusNotificationPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload:
     current_time: str
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload:
     status: GenericStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StartTransactionPayload:
     transaction_id: int
     id_tag_info: IdTagInfo
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StopTransactionPayload:
     id_tag_info: Optional[IdTagInfo] = None
@@ -112,52 +337,62 @@ class StopTransactionPayload:
 # listed in the bottom part of this module.
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CancelReservationPayload:
     status: CancelReservationStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload:
     status: CertificateSignedStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload:
     status: AvailabilityStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeConfigurationPayload:
     status: ConfigurationStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload:
     status: ClearCacheStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload:
     status: ClearChargingProfileStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload:
     status: DeleteCertificateStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ExtendedTriggerMessagePayload:
     status: TriggerMessageStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload:
     status: GetInstalledCertificateStatus
     certificate_hash_data: Optional[List] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload:
     status: GetCompositeScheduleStatus
@@ -166,83 +401,99 @@ class GetCompositeSchedulePayload:
     charging_schedule: Optional[Dict] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetConfigurationPayload:
     configuration_key: Optional[List] = None
     unknown_key: Optional[List] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDiagnosticsPayload:
     file_name: Optional[str] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload:
     list_version: int
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload:
     status: LogStatus
     filename: Optional[str] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload:
     status: CertificateStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStartTransactionPayload:
     status: RemoteStartStopStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStopTransactionPayload:
     status: RemoteStartStopStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload:
     status: ReservationStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload:
     status: ResetStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload:
     status: UpdateStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload:
     status: ChargingProfileStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedFirmwareStatusNotificationPayload:
     pass
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedUpdateFirmwarePayload:
     status: UpdateFirmwareStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload:
     status: TriggerMessageStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload:
     status: UnlockStatus
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload:
     pass
@@ -252,6 +503,7 @@ class UpdateFirmwarePayload:
 # from a Charge Point.
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DataTransferPayload:
     status: DataTransferStatus

--- a/ocpp/v16/call_result.py
+++ b/ocpp/v16/call_result.py
@@ -263,96 +263,156 @@ class DataTransfer:
 @dataclass
 class AuthorizePayload(Authorize):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload(BootNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DiagnosticsStatusNotificationPayload(DiagnosticsStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload(Heartbeat):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload(LogStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload(SecurityEventNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload(SignCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload(MeterValues):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StartTransactionPayload(StartTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload(StatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StopTransactionPayload(StopTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # The CALLRESULT messages that flow from Charge Point to Central System are
@@ -363,207 +423,338 @@ class StopTransactionPayload(StopTransaction):
 @dataclass
 class CancelReservationPayload(CancelReservation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload(CertificateSigned):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload(ChangeAvailability):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeConfigurationPayload(ChangeConfiguration):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload(ClearCache):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload(ClearChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload(DeleteCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ExtendedTriggerMessagePayload(ExtendedTriggerMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload(GetCompositeSchedule):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetConfigurationPayload(GetConfiguration):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDiagnosticsPayload(GetDiagnostics):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload(GetLocalListVersion):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload(GetLog):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload(InstallCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
+
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStartTransactionPayload(RemoteStartTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RemoteStopTransactionPayload(RemoteStopTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload(ReserveNow):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload(Reset):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload(SendLocalList):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload(SetChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedFirmwareStatusNotificationPayload(SignedFirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignedUpdateFirmwarePayload(SignedUpdateFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload(TriggerMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload(UnlockConnector):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload(UpdateFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # The DataTransfer CALLRESULT can be send both from Central System as well as
@@ -574,5 +765,10 @@ class UpdateFirmwarePayload(UpdateFirmware):
 @dataclass
 class DataTransferPayload(DataTransfer):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )

--- a/ocpp/v201/call.py
+++ b/ocpp/v201/call.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
-class AuthorizePayload:
+class Authorize:
     id_token: Dict
     certificate: Optional[str] = None
     iso15118_certificate_hash_data: Optional[List] = None
@@ -11,18 +11,510 @@ class AuthorizePayload:
 
 
 @dataclass
-class BootNotificationPayload:
+class BootNotification:
     charging_station: Dict
     reason: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
 @dataclass
+class CancelReservation:
+    reservation_id: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CertificateSigned:
+    certificate_chain: str
+    certificate_type: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ChangeAvailability:
+    operational_status: str
+    evse: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearCache:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearChargingProfile:
+    charging_profile_id: Optional[int] = None
+    charging_profile_criteria: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearDisplayMessage:
+    id: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearVariableMonitoring:
+    id: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearedChargingLimit:
+    charging_limit_source: str
+    evse_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CostUpdated:
+    total_cost: int
+    transaction_id: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CustomerInformation:
+    request_id: int
+    report: bool
+    clear: bool
+    customer_certificate: Optional[Dict] = None
+    id_token: Optional[Dict] = None
+    customer_identifier: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DataTransfer:
+    vendor_id: str
+    message_id: Optional[str] = None
+    data: Optional[Any] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DeleteCertificate:
+    certificate_hash_data: Dict
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class FirmwareStatusNotification:
+    status: str
+    request_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Get15118EVCertificate:
+    iso15118_schema_version: str
+    action: str
+    exi_request: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetBaseReport:
+    request_id: int
+    report_base: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetCertificateStatus:
+    ocsp_request_data: Dict
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetChargingProfiles:
+    request_id: int
+    charging_profile: Dict
+    evse_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetCompositeSchedule:
+    duration: int
+    evse_id: int
+    charging_rate_unit: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetDisplayMessages:
+    request_id: int
+    id: Optional[List] = None
+    priority: Optional[str] = None
+    state: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetInstalledCertificateIds:
+    certificate_type: Optional[List] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetLocalListVersion:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetLog:
+    log: Dict
+    log_type: str
+    request_id: int
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetMonitoringReport:
+    request_id: int
+    component_variable: Optional[List] = None
+    monitoring_criteria: Optional[List] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetReport:
+    request_id: int
+    component_variable: Optional[List] = None
+    component_criteria: Optional[List] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetTransactionStatus:
+    transaction_id: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetVariables:
+    get_variable_data: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Heartbeat:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class InstallCertificate:
+    certificate_type: str
+    certificate: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class LogStatusNotification:
+    status: str
+    request_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class MeterValues:
+    evse_id: int
+    meter_value: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyChargingLimit:
+    charging_limit: Dict
+    charging_schedule: Optional[List] = None
+    evse_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyCustomerInformation:
+    data: str
+    seq_no: int
+    generated_at: str
+    request_id: int
+    tbc: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyDisplayMessages:
+    request_id: int
+    message_info: Optional[List] = None
+    tbc: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyEVChargingNeeds:
+    charging_needs: Dict
+    evse_id: int
+    max_schedule_tuples: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyEVChargingSchedule:
+    time_base: str
+    charging_schedule: Dict
+    evse_id: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyEvent:
+    generated_at: str
+    seq_no: int
+    event_data: List
+    tbc: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyMonitoringReport:
+    request_id: int
+    seq_no: int
+    generated_at: str
+    monitor: Optional[List] = None
+    tbc: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyReport:
+    request_id: int
+    generated_at: str
+    seq_no: int
+    report_data: Optional[List] = None
+    tbc: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class PublishFirmware:
+    location: str
+    checksum: str
+    request_id: int
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class PublishFirmwareStatusNotification:
+    status: str
+    location: Optional[List] = None
+    request_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ReportChargingProfiles:
+    request_id: int
+    charging_limit_source: str
+    charging_profile: List
+    evse_id: int
+    tbc: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RequestStartTransaction:
+    id_token: Dict
+    remote_start_id: int
+    evse_id: Optional[int] = None
+    group_id_token: Optional[Dict] = None
+    charging_profile: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RequestStopTransaction:
+    transaction_id: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ReservationStatusUpdate:
+    reservation_id: int
+    reservation_update_status: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ReserveNow:
+    id: int
+    expiry_date_time: str
+    id_token: Dict
+    connector_type: Optional[str] = None
+    evse_id: Optional[int] = None
+    group_id_token: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Reset:
+    type: str
+    evse_id: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SecurityEventNotification:
+    type: str
+    timestamp: str
+    tech_info: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SendLocalList:
+    version_number: int
+    update_type: str
+    local_authorization_list: Optional[List] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetChargingProfile:
+    evse_id: int
+    charging_profile: Dict
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetDisplayMessage:
+    message: Dict
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetMonitoringBase:
+    monitoring_base: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetMonitoringLevel:
+    severity: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetNetworkProfile:
+    configuration_slot: int
+    connection_data: Dict
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetVariableMonitoring:
+    set_monitoring_data: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetVariables:
+    set_variable_data: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SignCertificate:
+    csr: str
+    certificate_type: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class StatusNotification:
+    timestamp: str
+    connector_status: str
+    evse_id: int
+    connector_id: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class TransactionEvent:
+    event_type: str
+    timestamp: str
+    trigger_reason: str
+    seq_no: int
+    transaction_info: Dict
+    meter_value: Optional[List] = None
+    offline: Optional[bool] = None
+    number_of_phases_used: Optional[int] = None
+    cable_max_current: Optional[int] = None
+    reservation_id: Optional[int] = None
+    evse: Optional[Dict] = None
+    id_token: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class TriggerMessage:
+    requested_message: str
+    evse: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class UnlockConnector:
+    evse_id: int
+    connector_id: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class UnpublishFirmware:
+    checksum: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class UpdateFirmware:
+    request_id: int
+    firmware: Dict
+    retries: Optional[int] = None
+    retry_interval: Optional[int] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
+class AuthorizePayload:
+    id_token: Dict
+    certificate: Optional[str] = None
+    iso15118_certificate_hash_data: Optional[List] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
+class BootNotificationPayload:
+    charging_station: Dict
+    reason: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
 class CancelReservationPayload:
     reservation_id: int
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload:
     certificate_chain: str
@@ -30,6 +522,7 @@ class CertificateSignedPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload:
     operational_status: str
@@ -37,11 +530,13 @@ class ChangeAvailabilityPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload:
     charging_profile_id: Optional[int] = None
@@ -49,18 +544,21 @@ class ClearChargingProfilePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearDisplayMessagePayload:
     id: int
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearVariableMonitoringPayload:
     id: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearedChargingLimitPayload:
     charging_limit_source: str
@@ -68,6 +566,7 @@ class ClearedChargingLimitPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CostUpdatedPayload:
     total_cost: int
@@ -75,6 +574,7 @@ class CostUpdatedPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CustomerInformationPayload:
     request_id: int
@@ -86,6 +586,7 @@ class CustomerInformationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DataTransferPayload:
     vendor_id: str
@@ -94,12 +595,14 @@ class DataTransferPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload:
     certificate_hash_data: Dict
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload:
     status: str
@@ -107,6 +610,7 @@ class FirmwareStatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class Get15118EVCertificatePayload:
     iso15118_schema_version: str
@@ -115,6 +619,7 @@ class Get15118EVCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetBaseReportPayload:
     request_id: int
@@ -122,12 +627,14 @@ class GetBaseReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCertificateStatusPayload:
     ocsp_request_data: Dict
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetChargingProfilesPayload:
     request_id: int
@@ -136,6 +643,7 @@ class GetChargingProfilesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload:
     duration: int
@@ -144,6 +652,7 @@ class GetCompositeSchedulePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDisplayMessagesPayload:
     request_id: int
@@ -153,17 +662,20 @@ class GetDisplayMessagesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload:
     certificate_type: Optional[List] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload:
     log: Dict
@@ -174,6 +686,7 @@ class GetLogPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetMonitoringReportPayload:
     request_id: int
@@ -182,6 +695,7 @@ class GetMonitoringReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetReportPayload:
     request_id: int
@@ -190,23 +704,27 @@ class GetReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetTransactionStatusPayload:
     transaction_id: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetVariablesPayload:
     get_variable_data: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload:
     certificate_type: str
@@ -214,6 +732,7 @@ class InstallCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload:
     status: str
@@ -221,6 +740,7 @@ class LogStatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload:
     evse_id: int
@@ -228,6 +748,7 @@ class MeterValuesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyChargingLimitPayload:
     charging_limit: Dict
@@ -236,6 +757,7 @@ class NotifyChargingLimitPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyCustomerInformationPayload:
     data: str
@@ -246,6 +768,7 @@ class NotifyCustomerInformationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyDisplayMessagesPayload:
     request_id: int
@@ -254,6 +777,7 @@ class NotifyDisplayMessagesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingNeedsPayload:
     charging_needs: Dict
@@ -262,6 +786,7 @@ class NotifyEVChargingNeedsPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingSchedulePayload:
     time_base: str
@@ -270,6 +795,7 @@ class NotifyEVChargingSchedulePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEventPayload:
     generated_at: str
@@ -279,6 +805,7 @@ class NotifyEventPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyMonitoringReportPayload:
     request_id: int
@@ -289,6 +816,7 @@ class NotifyMonitoringReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyReportPayload:
     request_id: int
@@ -299,6 +827,7 @@ class NotifyReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwarePayload:
     location: str
@@ -309,6 +838,7 @@ class PublishFirmwarePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwareStatusNotificationPayload:
     status: str
@@ -317,6 +847,7 @@ class PublishFirmwareStatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReportChargingProfilesPayload:
     request_id: int
@@ -327,6 +858,7 @@ class ReportChargingProfilesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStartTransactionPayload:
     id_token: Dict
@@ -337,12 +869,14 @@ class RequestStartTransactionPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStopTransactionPayload:
     transaction_id: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReservationStatusUpdatePayload:
     reservation_id: int
@@ -350,6 +884,7 @@ class ReservationStatusUpdatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload:
     id: int
@@ -361,6 +896,7 @@ class ReserveNowPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload:
     type: str
@@ -368,6 +904,7 @@ class ResetPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload:
     type: str
@@ -376,6 +913,7 @@ class SecurityEventNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload:
     version_number: int
@@ -384,6 +922,7 @@ class SendLocalListPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload:
     evse_id: int
@@ -391,24 +930,28 @@ class SetChargingProfilePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetDisplayMessagePayload:
     message: Dict
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringBasePayload:
     monitoring_base: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringLevelPayload:
     severity: int
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetNetworkProfilePayload:
     configuration_slot: int
@@ -416,18 +959,21 @@ class SetNetworkProfilePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariableMonitoringPayload:
     set_monitoring_data: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariablesPayload:
     set_variable_data: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload:
     csr: str
@@ -435,6 +981,7 @@ class SignCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload:
     timestamp: str
@@ -444,6 +991,7 @@ class StatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TransactionEventPayload:
     event_type: str
@@ -461,6 +1009,7 @@ class TransactionEventPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload:
     requested_message: str
@@ -468,6 +1017,7 @@ class TriggerMessagePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload:
     evse_id: int
@@ -475,12 +1025,14 @@ class UnlockConnectorPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnpublishFirmwarePayload:
     checksum: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload:
     request_id: int

--- a/ocpp/v201/call.py
+++ b/ocpp/v201/call.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -492,551 +493,511 @@ class UpdateFirmware:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class AuthorizePayload:
-    id_token: Dict
-    certificate: Optional[str] = None
-    iso15118_certificate_hash_data: Optional[List] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class AuthorizePayload(Authorize):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class BootNotificationPayload:
-    charging_station: Dict
-    reason: str
-    custom_data: Optional[Dict[str, Any]] = None
+class BootNotificationPayload(BootNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CancelReservationPayload:
-    reservation_id: int
-    custom_data: Optional[Dict[str, Any]] = None
+class CancelReservationPayload(CancelReservation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CertificateSignedPayload:
-    certificate_chain: str
-    certificate_type: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class CertificateSignedPayload(CertificateSigned):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ChangeAvailabilityPayload:
-    operational_status: str
-    evse: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ChangeAvailabilityPayload(ChangeAvailability):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearCachePayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearCachePayload(ClearCache):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearChargingProfilePayload:
-    charging_profile_id: Optional[int] = None
-    charging_profile_criteria: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearChargingProfilePayload(ClearChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearDisplayMessagePayload:
-    id: int
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearDisplayMessagePayload(ClearDisplayMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearVariableMonitoringPayload:
-    id: List
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearVariableMonitoringPayload(ClearVariableMonitoring):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearedChargingLimitPayload:
-    charging_limit_source: str
-    evse_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearedChargingLimitPayload(ClearedChargingLimit):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CostUpdatedPayload:
-    total_cost: int
-    transaction_id: str
-    custom_data: Optional[Dict[str, Any]] = None
+class CostUpdatedPayload(CostUpdated):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CustomerInformationPayload:
-    request_id: int
-    report: bool
-    clear: bool
-    customer_certificate: Optional[Dict] = None
-    id_token: Optional[Dict] = None
-    customer_identifier: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class CustomerInformationPayload(CustomerInformation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DataTransferPayload:
-    vendor_id: str
-    message_id: Optional[str] = None
-    data: Optional[Any] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class DataTransferPayload(DataTransfer):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DeleteCertificatePayload:
-    certificate_hash_data: Dict
-    custom_data: Optional[Dict[str, Any]] = None
+class DeleteCertificatePayload(DeleteCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class FirmwareStatusNotificationPayload:
-    status: str
-    request_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class Get15118EVCertificatePayload:
-    iso15118_schema_version: str
-    action: str
-    exi_request: str
-    custom_data: Optional[Dict[str, Any]] = None
+class Get15118EVCertificatePayload(Get15118EVCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetBaseReportPayload:
-    request_id: int
-    report_base: str
-    custom_data: Optional[Dict[str, Any]] = None
+class GetBaseReportPayload(GetBaseReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetCertificateStatusPayload:
-    ocsp_request_data: Dict
-    custom_data: Optional[Dict[str, Any]] = None
+class GetCertificateStatusPayload(GetCertificateStatus):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetChargingProfilesPayload:
-    request_id: int
-    charging_profile: Dict
-    evse_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetChargingProfilesPayload(GetChargingProfiles):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetCompositeSchedulePayload:
-    duration: int
-    evse_id: int
-    charging_rate_unit: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetCompositeSchedulePayload(GetCompositeSchedule):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetDisplayMessagesPayload:
-    request_id: int
-    id: Optional[List] = None
-    priority: Optional[str] = None
-    state: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetDisplayMessagesPayload(GetDisplayMessages):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetInstalledCertificateIdsPayload:
-    certificate_type: Optional[List] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLocalListVersionPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class GetLocalListVersionPayload(GetLocalListVersion):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLogPayload:
-    log: Dict
-    log_type: str
-    request_id: int
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetLogPayload(GetLog):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetMonitoringReportPayload:
-    request_id: int
-    component_variable: Optional[List] = None
-    monitoring_criteria: Optional[List] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetMonitoringReportPayload(GetMonitoringReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetReportPayload:
-    request_id: int
-    component_variable: Optional[List] = None
-    component_criteria: Optional[List] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetReportPayload(GetReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetTransactionStatusPayload:
-    transaction_id: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetTransactionStatusPayload(GetTransactionStatus):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetVariablesPayload:
-    get_variable_data: List
-    custom_data: Optional[Dict[str, Any]] = None
+class GetVariablesPayload(GetVariables):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class HeartbeatPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class HeartbeatPayload(Heartbeat):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class InstallCertificatePayload:
-    certificate_type: str
-    certificate: str
-    custom_data: Optional[Dict[str, Any]] = None
+class InstallCertificatePayload(InstallCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class LogStatusNotificationPayload:
-    status: str
-    request_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class LogStatusNotificationPayload(LogStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class MeterValuesPayload:
-    evse_id: int
-    meter_value: List
-    custom_data: Optional[Dict[str, Any]] = None
+class MeterValuesPayload(MeterValues):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyChargingLimitPayload:
-    charging_limit: Dict
-    charging_schedule: Optional[List] = None
-    evse_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyChargingLimitPayload(NotifyChargingLimit):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyCustomerInformationPayload:
-    data: str
-    seq_no: int
-    generated_at: str
-    request_id: int
-    tbc: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyCustomerInformationPayload(NotifyCustomerInformation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyDisplayMessagesPayload:
-    request_id: int
-    message_info: Optional[List] = None
-    tbc: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyDisplayMessagesPayload(NotifyDisplayMessages):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyEVChargingNeedsPayload:
-    charging_needs: Dict
-    evse_id: int
-    max_schedule_tuples: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyEVChargingNeedsPayload(NotifyEVChargingNeeds):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyEVChargingSchedulePayload:
-    time_base: str
-    charging_schedule: Dict
-    evse_id: int
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyEVChargingSchedulePayload(NotifyEVChargingSchedule):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyEventPayload:
-    generated_at: str
-    seq_no: int
-    event_data: List
-    tbc: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyEventPayload(NotifyEvent):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyMonitoringReportPayload:
-    request_id: int
-    seq_no: int
-    generated_at: str
-    monitor: Optional[List] = None
-    tbc: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyMonitoringReportPayload(NotifyMonitoringReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyReportPayload:
-    request_id: int
-    generated_at: str
-    seq_no: int
-    report_data: Optional[List] = None
-    tbc: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyReportPayload(NotifyReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class PublishFirmwarePayload:
-    location: str
-    checksum: str
-    request_id: int
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class PublishFirmwarePayload(PublishFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class PublishFirmwareStatusNotificationPayload:
-    status: str
-    location: Optional[List] = None
-    request_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class PublishFirmwareStatusNotificationPayload(PublishFirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReportChargingProfilesPayload:
-    request_id: int
-    charging_limit_source: str
-    charging_profile: List
-    evse_id: int
-    tbc: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ReportChargingProfilesPayload(ReportChargingProfiles):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RequestStartTransactionPayload:
-    id_token: Dict
-    remote_start_id: int
-    evse_id: Optional[int] = None
-    group_id_token: Optional[Dict] = None
-    charging_profile: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class RequestStartTransactionPayload(RequestStartTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RequestStopTransactionPayload:
-    transaction_id: str
-    custom_data: Optional[Dict[str, Any]] = None
+class RequestStopTransactionPayload(RequestStopTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReservationStatusUpdatePayload:
-    reservation_id: int
-    reservation_update_status: str
-    custom_data: Optional[Dict[str, Any]] = None
+class ReservationStatusUpdatePayload(ReservationStatusUpdate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReserveNowPayload:
-    id: int
-    expiry_date_time: str
-    id_token: Dict
-    connector_type: Optional[str] = None
-    evse_id: Optional[int] = None
-    group_id_token: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ReserveNowPayload(ReserveNow):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ResetPayload:
-    type: str
-    evse_id: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ResetPayload(Reset):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SecurityEventNotificationPayload:
-    type: str
-    timestamp: str
-    tech_info: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SecurityEventNotificationPayload(SecurityEventNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SendLocalListPayload:
-    version_number: int
-    update_type: str
-    local_authorization_list: Optional[List] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SendLocalListPayload(SendLocalList):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetChargingProfilePayload:
-    evse_id: int
-    charging_profile: Dict
-    custom_data: Optional[Dict[str, Any]] = None
+class SetChargingProfilePayload(SetChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetDisplayMessagePayload:
-    message: Dict
-    custom_data: Optional[Dict[str, Any]] = None
+class SetDisplayMessagePayload(SetDisplayMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetMonitoringBasePayload:
-    monitoring_base: str
-    custom_data: Optional[Dict[str, Any]] = None
+class SetMonitoringBasePayload(SetMonitoringBase):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetMonitoringLevelPayload:
-    severity: int
-    custom_data: Optional[Dict[str, Any]] = None
+class SetMonitoringLevelPayload(SetMonitoringLevel):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetNetworkProfilePayload:
-    configuration_slot: int
-    connection_data: Dict
-    custom_data: Optional[Dict[str, Any]] = None
+class SetNetworkProfilePayload(SetNetworkProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetVariableMonitoringPayload:
-    set_monitoring_data: List
-    custom_data: Optional[Dict[str, Any]] = None
+class SetVariableMonitoringPayload(SetVariableMonitoring):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetVariablesPayload:
-    set_variable_data: List
-    custom_data: Optional[Dict[str, Any]] = None
+class SetVariablesPayload(SetVariables):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignCertificatePayload:
-    csr: str
-    certificate_type: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SignCertificatePayload(SignCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StatusNotificationPayload:
-    timestamp: str
-    connector_status: str
-    evse_id: int
-    connector_id: int
-    custom_data: Optional[Dict[str, Any]] = None
+class StatusNotificationPayload(StatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class TransactionEventPayload:
-    event_type: str
-    timestamp: str
-    trigger_reason: str
-    seq_no: int
-    transaction_info: Dict
-    meter_value: Optional[List] = None
-    offline: Optional[bool] = None
-    number_of_phases_used: Optional[int] = None
-    cable_max_current: Optional[int] = None
-    reservation_id: Optional[int] = None
-    evse: Optional[Dict] = None
-    id_token: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class TransactionEventPayload(TransactionEvent):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class TriggerMessagePayload:
-    requested_message: str
-    evse: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class TriggerMessagePayload(TriggerMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UnlockConnectorPayload:
-    evse_id: int
-    connector_id: int
-    custom_data: Optional[Dict[str, Any]] = None
+class UnlockConnectorPayload(UnlockConnector):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UnpublishFirmwarePayload:
-    checksum: str
-    custom_data: Optional[Dict[str, Any]] = None
+class UnpublishFirmwarePayload(UnpublishFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UpdateFirmwarePayload:
-    request_id: int
-    firmware: Dict
-    retries: Optional[int] = None
-    retry_interval: Optional[int] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class UpdateFirmwarePayload(UpdateFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))

--- a/ocpp/v201/call.py
+++ b/ocpp/v201/call.py
@@ -495,509 +495,829 @@ class UpdateFirmware:
 @dataclass
 class AuthorizePayload(Authorize):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload(BootNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CancelReservationPayload(CancelReservation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload(CertificateSigned):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload(ChangeAvailability):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload(ClearCache):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload(ClearChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearDisplayMessagePayload(ClearDisplayMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearVariableMonitoringPayload(ClearVariableMonitoring):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearedChargingLimitPayload(ClearedChargingLimit):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CostUpdatedPayload(CostUpdated):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CustomerInformationPayload(CustomerInformation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DataTransferPayload(DataTransfer):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload(DeleteCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class Get15118EVCertificatePayload(Get15118EVCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetBaseReportPayload(GetBaseReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCertificateStatusPayload(GetCertificateStatus):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetChargingProfilesPayload(GetChargingProfiles):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload(GetCompositeSchedule):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDisplayMessagesPayload(GetDisplayMessages):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload(GetLocalListVersion):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload(GetLog):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetMonitoringReportPayload(GetMonitoringReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetReportPayload(GetReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetTransactionStatusPayload(GetTransactionStatus):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetVariablesPayload(GetVariables):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload(Heartbeat):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload(InstallCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload(LogStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload(MeterValues):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyChargingLimitPayload(NotifyChargingLimit):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyCustomerInformationPayload(NotifyCustomerInformation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyDisplayMessagesPayload(NotifyDisplayMessages):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingNeedsPayload(NotifyEVChargingNeeds):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingSchedulePayload(NotifyEVChargingSchedule):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEventPayload(NotifyEvent):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyMonitoringReportPayload(NotifyMonitoringReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyReportPayload(NotifyReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwarePayload(PublishFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwareStatusNotificationPayload(PublishFirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReportChargingProfilesPayload(ReportChargingProfiles):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStartTransactionPayload(RequestStartTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStopTransactionPayload(RequestStopTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReservationStatusUpdatePayload(ReservationStatusUpdate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload(ReserveNow):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload(Reset):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload(SecurityEventNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload(SendLocalList):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload(SetChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetDisplayMessagePayload(SetDisplayMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringBasePayload(SetMonitoringBase):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringLevelPayload(SetMonitoringLevel):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetNetworkProfilePayload(SetNetworkProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariableMonitoringPayload(SetVariableMonitoring):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariablesPayload(SetVariables):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload(SignCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload(StatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TransactionEventPayload(TransactionEvent):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload(TriggerMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload(UnlockConnector):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnpublishFirmwarePayload(UnpublishFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload(UpdateFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -3,12 +3,434 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
+class Authorize:
+    id_token_info: Dict
+    certificate_status: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class BootNotification:
+    current_time: str
+    interval: int
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CancelReservation:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CertificateSigned:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ChangeAvailability:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearCache:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearChargingProfile:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearDisplayMessage:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearVariableMonitoring:
+    clear_monitoring_result: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ClearedChargingLimit:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CostUpdated:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class CustomerInformation:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DataTransfer:
+    status: str
+    status_info: Optional[Dict] = None
+    data: Optional[Any] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DeleteCertificate:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class FirmwareStatusNotification:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Get15118EVCertificate:
+    status: str
+    exi_response: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetBaseReport:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetCertificateStatus:
+    status: str
+    status_info: Optional[Dict] = None
+    ocsp_result: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetChargingProfiles:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetCompositeSchedule:
+    status: str
+    status_info: Optional[Dict] = None
+    schedule: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetDisplayMessages:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetInstalledCertificateIds:
+    status: str
+    status_info: Optional[Dict] = None
+    certificate_hash_data_chain: Optional[List] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetLocalListVersion:
+    version_number: int
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetLog:
+    status: str
+    status_info: Optional[Dict] = None
+    filename: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetMonitoringReport:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetReport:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetTransactionStatus:
+    messages_in_queue: bool
+    ongoing_indicator: Optional[bool] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class GetVariables:
+    get_variable_result: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Heartbeat:
+    current_time: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class InstallCertificate:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class LogStatusNotification:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class MeterValues:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyChargingLimit:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyCustomerInformation:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyDisplayMessages:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyEVChargingNeeds:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyEVChargingSchedule:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyEvent:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyMonitoringReport:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class NotifyReport:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class PublishFirmware:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class PublishFirmwareStatusNotification:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ReportChargingProfiles:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RequestStartTransaction:
+    status: str
+    status_info: Optional[Dict] = None
+    transaction_id: Optional[str] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RequestStopTransaction:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ReservationStatusUpdate:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ReserveNow:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Reset:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SecurityEventNotification:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SendLocalList:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetChargingProfile:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetDisplayMessage:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetMonitoringBase:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetMonitoringLevel:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetNetworkProfile:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetVariableMonitoring:
+    set_monitoring_result: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SetVariables:
+    set_variable_result: List
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class SignCertificate:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class StatusNotification:
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class TransactionEvent:
+    total_cost: Optional[int] = None
+    charging_priority: Optional[int] = None
+    id_token_info: Optional[Dict] = None
+    updated_personal_message: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class TriggerMessage:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class UnlockConnector:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class UnpublishFirmware:
+    status: str
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class UpdateFirmware:
+    status: str
+    status_info: Optional[Dict] = None
+    custom_data: Optional[Dict[str, Any]] = None
+
+
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
+@dataclass
 class AuthorizePayload:
     id_token_info: Dict
     certificate_status: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload:
     current_time: str
@@ -18,6 +440,7 @@ class BootNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CancelReservationPayload:
     status: str
@@ -25,6 +448,7 @@ class CancelReservationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload:
     status: str
@@ -32,6 +456,7 @@ class CertificateSignedPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload:
     status: str
@@ -39,6 +464,7 @@ class ChangeAvailabilityPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload:
     status: str
@@ -46,6 +472,7 @@ class ClearCachePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload:
     status: str
@@ -53,6 +480,7 @@ class ClearChargingProfilePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearDisplayMessagePayload:
     status: str
@@ -60,22 +488,26 @@ class ClearDisplayMessagePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearVariableMonitoringPayload:
     clear_monitoring_result: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearedChargingLimitPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CostUpdatedPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CustomerInformationPayload:
     status: str
@@ -83,6 +515,7 @@ class CustomerInformationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DataTransferPayload:
     status: str
@@ -91,6 +524,7 @@ class DataTransferPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload:
     status: str
@@ -98,11 +532,13 @@ class DeleteCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class Get15118EVCertificatePayload:
     status: str
@@ -111,6 +547,7 @@ class Get15118EVCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetBaseReportPayload:
     status: str
@@ -118,6 +555,7 @@ class GetBaseReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCertificateStatusPayload:
     status: str
@@ -126,6 +564,7 @@ class GetCertificateStatusPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetChargingProfilesPayload:
     status: str
@@ -133,6 +572,7 @@ class GetChargingProfilesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload:
     status: str
@@ -141,6 +581,7 @@ class GetCompositeSchedulePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDisplayMessagesPayload:
     status: str
@@ -148,6 +589,7 @@ class GetDisplayMessagesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload:
     status: str
@@ -156,12 +598,14 @@ class GetInstalledCertificateIdsPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload:
     version_number: int
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload:
     status: str
@@ -170,6 +614,7 @@ class GetLogPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetMonitoringReportPayload:
     status: str
@@ -177,6 +622,7 @@ class GetMonitoringReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetReportPayload:
     status: str
@@ -184,6 +630,7 @@ class GetReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetTransactionStatusPayload:
     messages_in_queue: bool
@@ -191,18 +638,21 @@ class GetTransactionStatusPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetVariablesPayload:
     get_variable_result: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload:
     current_time: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload:
     status: str
@@ -210,31 +660,37 @@ class InstallCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyChargingLimitPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyCustomerInformationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyDisplayMessagesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingNeedsPayload:
     status: str
@@ -242,6 +698,7 @@ class NotifyEVChargingNeedsPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingSchedulePayload:
     status: str
@@ -249,21 +706,25 @@ class NotifyEVChargingSchedulePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEventPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyMonitoringReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyReportPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwarePayload:
     status: str
@@ -271,16 +732,19 @@ class PublishFirmwarePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwareStatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReportChargingProfilesPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStartTransactionPayload:
     status: str
@@ -289,6 +753,7 @@ class RequestStartTransactionPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStopTransactionPayload:
     status: str
@@ -296,11 +761,13 @@ class RequestStopTransactionPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReservationStatusUpdatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload:
     status: str
@@ -308,6 +775,7 @@ class ReserveNowPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload:
     status: str
@@ -315,11 +783,13 @@ class ResetPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload:
     status: str
@@ -327,6 +797,7 @@ class SendLocalListPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload:
     status: str
@@ -334,6 +805,7 @@ class SetChargingProfilePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetDisplayMessagePayload:
     status: str
@@ -341,6 +813,7 @@ class SetDisplayMessagePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringBasePayload:
     status: str
@@ -348,6 +821,7 @@ class SetMonitoringBasePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringLevelPayload:
     status: str
@@ -355,6 +829,7 @@ class SetMonitoringLevelPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetNetworkProfilePayload:
     status: str
@@ -362,18 +837,21 @@ class SetNetworkProfilePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariableMonitoringPayload:
     set_monitoring_result: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariablesPayload:
     set_variable_result: List
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload:
     status: str
@@ -381,11 +859,13 @@ class SignCertificatePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TransactionEventPayload:
     total_cost: Optional[int] = None
@@ -395,6 +875,7 @@ class TransactionEventPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload:
     status: str
@@ -402,6 +883,7 @@ class TriggerMessagePayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload:
     status: str
@@ -409,12 +891,14 @@ class UnlockConnectorPayload:
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnpublishFirmwarePayload:
     status: str
     custom_data: Optional[Dict[str, Any]] = None
 
 
+# Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload:
     status: str

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -427,509 +427,829 @@ class UpdateFirmware:
 @dataclass
 class AuthorizePayload(Authorize):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class BootNotificationPayload(BootNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CancelReservationPayload(CancelReservation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CertificateSignedPayload(CertificateSigned):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ChangeAvailabilityPayload(ChangeAvailability):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearCachePayload(ClearCache):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearChargingProfilePayload(ClearChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearDisplayMessagePayload(ClearDisplayMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearVariableMonitoringPayload(ClearVariableMonitoring):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ClearedChargingLimitPayload(ClearedChargingLimit):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CostUpdatedPayload(CostUpdated):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class CustomerInformationPayload(CustomerInformation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DataTransferPayload(DataTransfer):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class DeleteCertificatePayload(DeleteCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class Get15118EVCertificatePayload(Get15118EVCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetBaseReportPayload(GetBaseReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCertificateStatusPayload(GetCertificateStatus):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetChargingProfilesPayload(GetChargingProfiles):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetCompositeSchedulePayload(GetCompositeSchedule):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetDisplayMessagesPayload(GetDisplayMessages):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLocalListVersionPayload(GetLocalListVersion):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetLogPayload(GetLog):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetMonitoringReportPayload(GetMonitoringReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetReportPayload(GetReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetTransactionStatusPayload(GetTransactionStatus):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class GetVariablesPayload(GetVariables):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class HeartbeatPayload(Heartbeat):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class InstallCertificatePayload(InstallCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class LogStatusNotificationPayload(LogStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class MeterValuesPayload(MeterValues):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyChargingLimitPayload(NotifyChargingLimit):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyCustomerInformationPayload(NotifyCustomerInformation):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyDisplayMessagesPayload(NotifyDisplayMessages):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingNeedsPayload(NotifyEVChargingNeeds):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEVChargingSchedulePayload(NotifyEVChargingSchedule):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyEventPayload(NotifyEvent):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyMonitoringReportPayload(NotifyMonitoringReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class NotifyReportPayload(NotifyReport):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwarePayload(PublishFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class PublishFirmwareStatusNotificationPayload(PublishFirmwareStatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReportChargingProfilesPayload(ReportChargingProfiles):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStartTransactionPayload(RequestStartTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class RequestStopTransactionPayload(RequestStopTransaction):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReservationStatusUpdatePayload(ReservationStatusUpdate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ReserveNowPayload(ReserveNow):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class ResetPayload(Reset):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SecurityEventNotificationPayload(SecurityEventNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SendLocalListPayload(SendLocalList):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetChargingProfilePayload(SetChargingProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetDisplayMessagePayload(SetDisplayMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringBasePayload(SetMonitoringBase):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetMonitoringLevelPayload(SetMonitoringLevel):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetNetworkProfilePayload(SetNetworkProfile):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariableMonitoringPayload(SetVariableMonitoring):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SetVariablesPayload(SetVariables):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class SignCertificatePayload(SignCertificate):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class StatusNotificationPayload(StatusNotification):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TransactionEventPayload(TransactionEvent):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class TriggerMessagePayload(TriggerMessage):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnlockConnectorPayload(UnlockConnector):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UnpublishFirmwarePayload(UnpublishFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
 class UpdateFirmwarePayload(UpdateFirmware):
     def __post_init__(self):
-        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
-                       __class__.__mro__[1].__name__))
+        warnings.warn(
+            (
+                __class__.__name__
+                + " is deprecated, use instead "
+                + __class__.__mro__[1].__name__
+            )
+        )

--- a/ocpp/v201/call_result.py
+++ b/ocpp/v201/call_result.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -424,483 +425,511 @@ class UpdateFirmware:
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class AuthorizePayload:
-    id_token_info: Dict
-    certificate_status: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class AuthorizePayload(Authorize):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class BootNotificationPayload:
-    current_time: str
-    interval: int
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class BootNotificationPayload(BootNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CancelReservationPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class CancelReservationPayload(CancelReservation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CertificateSignedPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class CertificateSignedPayload(CertificateSigned):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ChangeAvailabilityPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ChangeAvailabilityPayload(ChangeAvailability):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearCachePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearCachePayload(ClearCache):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearChargingProfilePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearChargingProfilePayload(ClearChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearDisplayMessagePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearDisplayMessagePayload(ClearDisplayMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearVariableMonitoringPayload:
-    clear_monitoring_result: List
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearVariableMonitoringPayload(ClearVariableMonitoring):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ClearedChargingLimitPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class ClearedChargingLimitPayload(ClearedChargingLimit):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CostUpdatedPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class CostUpdatedPayload(CostUpdated):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class CustomerInformationPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class CustomerInformationPayload(CustomerInformation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DataTransferPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    data: Optional[Any] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class DataTransferPayload(DataTransfer):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class DeleteCertificatePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class DeleteCertificatePayload(DeleteCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class FirmwareStatusNotificationPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class FirmwareStatusNotificationPayload(FirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class Get15118EVCertificatePayload:
-    status: str
-    exi_response: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class Get15118EVCertificatePayload(Get15118EVCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetBaseReportPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetBaseReportPayload(GetBaseReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetCertificateStatusPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    ocsp_result: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetCertificateStatusPayload(GetCertificateStatus):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetChargingProfilesPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetChargingProfilesPayload(GetChargingProfiles):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetCompositeSchedulePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    schedule: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetCompositeSchedulePayload(GetCompositeSchedule):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetDisplayMessagesPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetDisplayMessagesPayload(GetDisplayMessages):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetInstalledCertificateIdsPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    certificate_hash_data_chain: Optional[List] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetInstalledCertificateIdsPayload(GetInstalledCertificateIds):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLocalListVersionPayload:
-    version_number: int
-    custom_data: Optional[Dict[str, Any]] = None
+class GetLocalListVersionPayload(GetLocalListVersion):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetLogPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    filename: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetLogPayload(GetLog):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetMonitoringReportPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetMonitoringReportPayload(GetMonitoringReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetReportPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetReportPayload(GetReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetTransactionStatusPayload:
-    messages_in_queue: bool
-    ongoing_indicator: Optional[bool] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class GetTransactionStatusPayload(GetTransactionStatus):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class GetVariablesPayload:
-    get_variable_result: List
-    custom_data: Optional[Dict[str, Any]] = None
+class GetVariablesPayload(GetVariables):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class HeartbeatPayload:
-    current_time: str
-    custom_data: Optional[Dict[str, Any]] = None
+class HeartbeatPayload(Heartbeat):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class InstallCertificatePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class InstallCertificatePayload(InstallCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class LogStatusNotificationPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class LogStatusNotificationPayload(LogStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class MeterValuesPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class MeterValuesPayload(MeterValues):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyChargingLimitPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyChargingLimitPayload(NotifyChargingLimit):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyCustomerInformationPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyCustomerInformationPayload(NotifyCustomerInformation):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyDisplayMessagesPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyDisplayMessagesPayload(NotifyDisplayMessages):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyEVChargingNeedsPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyEVChargingNeedsPayload(NotifyEVChargingNeeds):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyEVChargingSchedulePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyEVChargingSchedulePayload(NotifyEVChargingSchedule):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyEventPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyEventPayload(NotifyEvent):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyMonitoringReportPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyMonitoringReportPayload(NotifyMonitoringReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class NotifyReportPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class NotifyReportPayload(NotifyReport):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class PublishFirmwarePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class PublishFirmwarePayload(PublishFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class PublishFirmwareStatusNotificationPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class PublishFirmwareStatusNotificationPayload(PublishFirmwareStatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReportChargingProfilesPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class ReportChargingProfilesPayload(ReportChargingProfiles):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RequestStartTransactionPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    transaction_id: Optional[str] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class RequestStartTransactionPayload(RequestStartTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class RequestStopTransactionPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class RequestStopTransactionPayload(RequestStopTransaction):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReservationStatusUpdatePayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class ReservationStatusUpdatePayload(ReservationStatusUpdate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ReserveNowPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ReserveNowPayload(ReserveNow):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class ResetPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class ResetPayload(Reset):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SecurityEventNotificationPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class SecurityEventNotificationPayload(SecurityEventNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SendLocalListPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SendLocalListPayload(SendLocalList):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetChargingProfilePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SetChargingProfilePayload(SetChargingProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetDisplayMessagePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SetDisplayMessagePayload(SetDisplayMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetMonitoringBasePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SetMonitoringBasePayload(SetMonitoringBase):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetMonitoringLevelPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SetMonitoringLevelPayload(SetMonitoringLevel):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetNetworkProfilePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SetNetworkProfilePayload(SetNetworkProfile):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetVariableMonitoringPayload:
-    set_monitoring_result: List
-    custom_data: Optional[Dict[str, Any]] = None
+class SetVariableMonitoringPayload(SetVariableMonitoring):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SetVariablesPayload:
-    set_variable_result: List
-    custom_data: Optional[Dict[str, Any]] = None
+class SetVariablesPayload(SetVariables):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class SignCertificatePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class SignCertificatePayload(SignCertificate):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class StatusNotificationPayload:
-    custom_data: Optional[Dict[str, Any]] = None
+class StatusNotificationPayload(StatusNotification):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class TransactionEventPayload:
-    total_cost: Optional[int] = None
-    charging_priority: Optional[int] = None
-    id_token_info: Optional[Dict] = None
-    updated_personal_message: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class TransactionEventPayload(TransactionEvent):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class TriggerMessagePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class TriggerMessagePayload(TriggerMessage):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UnlockConnectorPayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class UnlockConnectorPayload(UnlockConnector):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UnpublishFirmwarePayload:
-    status: str
-    custom_data: Optional[Dict[str, Any]] = None
+class UnpublishFirmwarePayload(UnpublishFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))
 
 
 # Dataclass soon to be deprecated use equal class name without the suffix 'Payload'
 @dataclass
-class UpdateFirmwarePayload:
-    status: str
-    status_info: Optional[Dict] = None
-    custom_data: Optional[Dict[str, Any]] = None
+class UpdateFirmwarePayload(UpdateFirmware):
+    def __post_init__(self):
+        warnings.warn((__class__.__name__ + " is deprecated, use instead " +
+                       __class__.__mro__[1].__name__))


### PR DESCRIPTION
Fixes #583 