### PR TITLE
In GA, validate project against Python 3.11 and 3.12. #564

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,6 +15,8 @@ jobs:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
+        - "3.12"
     steps:
       - uses: actions/checkout@master
       - name: Set up Python ${{ matrix.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change log
-
+- [#564](https://github.com/mobilityhouse/ocpp/issues/564) Add support For Python 3.11 and 3.12
 - [#583](https://github.com/mobilityhouse/ocpp/issues/583) OCPP v1.6/v2.0.1 deprecate dataclasses from calls and call results with the suffix 'Payload'
 
 ## 0.26.0 (2024-01-17)


### PR DESCRIPTION
see issue https://github.com/mobilityhouse/ocpp/issues/564