### PR TITLE
Update tests to use Call and CallResult without the suffix Payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 - [#583](https://github.com/mobilityhouse/ocpp/issues/583) OCPP v1.6/v2.0.1 deprecate dataclasses from calls and call results with the suffix 'Payload'
+- [#593](https://github.com/mobilityhouse/ocpp/issues/593) Update tests to use Call and CallResult without the suffix Payload
 
 ## 0.26.0 (2024-01-17)
 

--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -311,9 +311,14 @@ class ChargePoint:
             unique_id if unique_id is not None else str(self._unique_id_generator())
         )
 
+        action_name = payload.__class__.__name__
+        # Due to deprecated call and callresults, remove in the future.
+        if "Payload" in payload.__class__.__name__:
+            action_name = payload.__class__.__name__[:-7]
+
         call = Call(
             unique_id=unique_id,
-            action=payload.__class__.__name__[:-7],
+            action=action_name,
             payload=remove_nones(camel_case_payload),
         )
 

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -7,17 +7,17 @@ from ocpp.messages import Call
 from ocpp.routing import after, create_route_map, on
 from ocpp.v16 import ChargePoint as cp_16
 from ocpp.v16.call import (
-    BootNotificationPayload,
-    GetConfigurationPayload,
-    MeterValuesPayload,
+    BootNotification,
+    GetConfiguration,
+    MeterValues,
 )
 from ocpp.v16.call_result import (
-    BootNotificationPayload as BootNotificationResultPayload,
+    BootNotification as BootNotificationResult,
 )
 from ocpp.v16.datatypes import MeterValue, SampledValue
 from ocpp.v16.enums import Action, RegistrationStatus
 from ocpp.v20 import ChargePoint as cp_20
-from ocpp.v201.call import SetNetworkProfilePayload
+from ocpp.v201.call import SetNetworkProfile
 from ocpp.v201.datatypes import NetworkConnectionProfileType
 from ocpp.v201.enums import OCPPInterfaceType, OCPPTransportType, OCPPVersionType
 
@@ -82,7 +82,7 @@ def test_snake_to_camel_case(test_input, expected):
 def test_remove_nones():
     expected_payload = {"charge_point_model": "foo", "charge_point_vendor": "bar"}
 
-    payload = BootNotificationPayload(
+    payload = BootNotification(
         charge_point_model="foo",
         charge_point_vendor="bar",
         charge_box_serial_number=None,
@@ -116,9 +116,7 @@ def test_nested_remove_nones():
         apn=None,
     )
 
-    payload = SetNetworkProfilePayload(
-        configuration_slot=1, connection_data=connection_data
-    )
+    payload = SetNetworkProfile(configuration_slot=1, connection_data=connection_data)
     payload = asdict(payload)
 
     assert expected_payload == remove_nones(payload)
@@ -168,7 +166,7 @@ def test_nested_list_remove_nones():
         "transaction_id": 5,
     }
 
-    payload = MeterValuesPayload(
+    payload = MeterValues(
         connector_id=3,
         meter_value=[
             MeterValue(
@@ -231,7 +229,7 @@ def test_remove_nones_with_list_of_strings():
     https://github.com/mobilityhouse/ocpp/issues/289.
     """
     payload = asdict(
-        GetConfigurationPayload(key=["ClockAlignedDataInterval", "ConnectionTimeOut"])
+        GetConfiguration(key=["ClockAlignedDataInterval", "ConnectionTimeOut"])
     )
 
     assert remove_nones(payload) == {
@@ -274,7 +272,7 @@ async def test_call_unique_id_added_to_handler_args_correctly(connection):
             assert kwargs == camel_to_snake_case(payload_a)
             assert args == ()
             ChargerA.on_boot_notification_call_count += 1
-            return BootNotificationResultPayload(
+            return BootNotificationResult(
                 current_time="foo", interval=1, status=RegistrationStatus.accepted
             )
 
@@ -285,7 +283,7 @@ async def test_call_unique_id_added_to_handler_args_correctly(connection):
             # call_unique_id should not be passed as arg
             assert args == ()
             ChargerA.after_boot_notification_call_count += 1
-            return BootNotificationResultPayload(
+            return BootNotificationResult(
                 current_time="foo", interval=1, status=RegistrationStatus.accepted
             )
 
@@ -300,7 +298,7 @@ async def test_call_unique_id_added_to_handler_args_correctly(connection):
             # call_unique_id should not be passed as arg
             assert args == ()
             ChargerB.on_boot_notification_call_count += 1
-            return BootNotificationResultPayload(
+            return BootNotificationResult(
                 current_time="foo", interval=1, status=RegistrationStatus.accepted
             )
 
@@ -310,7 +308,7 @@ async def test_call_unique_id_added_to_handler_args_correctly(connection):
             assert kwargs == camel_to_snake_case(payload_b)
             assert args == ()
             ChargerB.after_boot_notification_call_count += 1
-            return BootNotificationResultPayload(
+            return BootNotificationResult(
                 current_time="foo", interval=1, status=RegistrationStatus.accepted
             )
 

--- a/tests/v16/conftest.py
+++ b/tests/v16/conftest.py
@@ -49,7 +49,7 @@ def base_central_system(connection):
 
 @pytest.fixture
 def mock_boot_request():
-    return call.BootNotificationPayload(
+    return call.BootNotification(
         charge_point_vendor="dummy_vendor",
         charge_point_model="dummy_model",
     )

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -26,7 +26,7 @@ async def test_route_message_with_existing_route(
         assert charge_point_model == "ICU Eve Mini"
         assert kwargs["firmware_version"] == "#1:3.4.0-2990#N:217H;1.0-223"
 
-        return call_result.BootNotificationPayload(
+        return call_result.BootNotification(
             current_time="2018-05-29T17:37:05.495259",
             interval=350,
             status="Accepted",
@@ -120,7 +120,7 @@ async def test_route_message_not_supported(base_central_system, not_supported_ca
     def on_boot_notification(**kwargs):  # noqa
         assert kwargs["firmware_version"] == "#1:3.4.0-2990#N:217H;1.0-223"
 
-        return call_result.BootNotificationPayload(
+        return call_result.BootNotification(
             current_time="2018-05-29T17:37:05.495259",
             interval=350,
             # 'Yolo' is not a valid value for for field status.
@@ -174,7 +174,7 @@ async def test_route_message_with_no_route(base_central_system, heartbeat_call):
 async def test_send_call_with_timeout(connection):
     cs = ChargePoint(id=1234, connection=connection, response_timeout=0.1)
 
-    payload = call.ResetPayload(type="Hard")
+    payload = call.Reset(type="Hard")
 
     with pytest.raises(asyncio.TimeoutError):
         await cs.call(payload)
@@ -187,7 +187,7 @@ async def test_send_call_with_timeout(connection):
 
 @pytest.mark.asyncio
 async def test_send_invalid_call(base_central_system):
-    payload = call.ResetPayload(type="Medium")
+    payload = call.Reset(type="Medium")
 
     with pytest.raises(FormatViolationError):
         await base_central_system.call(payload)
@@ -207,7 +207,7 @@ async def test_raise_call_error(base_central_system):
     )
     await base_central_system.route_message(call_error.to_json())
 
-    payload = call.ClearCachePayload()
+    payload = call.ClearCache()
     with pytest.raises(GenericError):
         await base_central_system.call(payload, suppress=False)
 
@@ -226,7 +226,7 @@ async def test_suppress_call_error(base_central_system):
     )
     await base_central_system.route_message(call_error.to_json())
 
-    payload = call.ClearCachePayload()
+    payload = call.ClearCache()
     await base_central_system.call(payload)
 
 

--- a/tests/v16/test_v16_charge_point.py
+++ b/tests/v16/test_v16_charge_point.py
@@ -66,7 +66,7 @@ async def test_route_message_without_validation(base_central_system):
     def on_boot_notification(**kwargs):  # noqa
         assert kwargs["firmware_version"] == "#1:3.4.0-2990#N:217H;1.0-223"
 
-        return call_result.BootNotificationPayload(
+        return call_result.BootNotification(
             current_time="2018-05-29T17:37:05.495259",
             interval=350,
             # 'Yolo' is not a valid value for for field status.

--- a/tests/v201/conftest.py
+++ b/tests/v201/conftest.py
@@ -48,7 +48,7 @@ def base_central_system(connection):
 
 @pytest.fixture
 def mock_boot_request():
-    return call.BootNotificationPayload(
+    return call.BootNotification(
         reason="PowerUp",
         charging_station=chargingStation,
     )

--- a/tests/v201/test_v201_charge_point.py
+++ b/tests/v201/test_v201_charge_point.py
@@ -24,7 +24,7 @@ async def test_route_message_with_existing_route(
             "model": "ICU Eve Mini",
         }
 
-        return call_result.BootNotificationPayload(
+        return call_result.BootNotification(
             current_time="2018-05-29T17:37:05.495259",
             interval=350,
             status="Accepted",


### PR DESCRIPTION
See issue https://github.com/mobilityhouse/ocpp/issues/593


Also major bug corrected in Master branch below:

        action_name = payload.__class__.__name__
        # Due to deprecated call and callresults, remove in the future.
        if "Payload" in payload.__class__.__name__:
            action_name = payload.__class__.__name__[:-7]
