### PR TITLE
Fix serialization of payloads that contain collection of multiple elements

### DIFF
--- a/ocpp/charge_point.py
+++ b/ocpp/charge_point.py
@@ -130,16 +130,18 @@ def serialize_as_dict(dataclass):
     serialized = asdict(dataclass)
 
     for field in dataclass.__dataclass_fields__.values():
-
         value = getattr(dataclass, field.name)
         if _is_dataclass_instance(value):
             serialized[field.name] = serialize_as_dict(value)
             continue
 
         if isinstance(value, list):
+            serialized[field.name] = []
             for item in value:
                 if _is_dataclass_instance(item):
-                    serialized[field.name] = [serialize_as_dict(item)]
+                    serialized[field.name].append(serialize_as_dict(item))
+                else:
+                    serialized[field.name].append(item)
 
     return serialized
 

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -16,9 +16,9 @@ from ocpp.v16.call_result import BootNotification as BootNotificationResult
 from ocpp.v16.datatypes import MeterValue, SampledValue
 from ocpp.v16.enums import Action, RegistrationStatus
 from ocpp.v201 import ChargePoint as cp_201
+from ocpp.v201 import call_result, datatypes, enums
 from ocpp.v201.call import GetVariables as v201GetVariables
 from ocpp.v201.call import SetNetworkProfile as v201SetNetworkProfile
-from ocpp.v201 import datatypes, call_result, enums
 from ocpp.v201.datatypes import (
     ComponentType,
     EVSEType,

--- a/tests/test_charge_point.py
+++ b/tests/test_charge_point.py
@@ -314,7 +314,7 @@ def test_serialize_as_dict():
 
 
 def test_serialization_of_collection_of_multiple_elements():
-    """ This test validates that bug #635 is fixed.
+    """This test validates that bug #635 is fixed.
     That bug incorrectly serialized payloads that contain a collection
     of elements.
 
@@ -372,6 +372,7 @@ def test_serialization_of_collection_of_multiple_elements():
     }
     # Execute / Assert
     assert serialize_as_dict(payload) == expected
+
 
 @pytest.mark.asyncio
 async def test_call_unique_id_added_to_handler_args_correctly(connection):


### PR DESCRIPTION
Serialization of a payload that contains a collection of items fails. Only the last item of the collection appears in the
serialized output. All other collections are not available.

Fixes #635 