### PR TITLE
chore: Added inactive issue workflow

### DIFF
--- a/.github/workflows/inactive-issue.yml
+++ b/.github/workflows/inactive-issue.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Issues that are stale for 30 days will be marked as `stale`
- Issues that are marked as `stale` for more than 14 days will be automatically closed.
- No changes will be done to PRs

Ref: https://docs.github.com/en/actions/use-cases-and-examples/project-management/closing-inactive-issues