### PR TITLE
Update readme - ocpp 2 edition 3 is supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ OCPP
 ----
 
 Python package implementing the JSON version of the Open Charge Point Protocol
-(OCPP). Currently OCPP 1.6 (errata v4), OCPP 2.0.1 (Edition 2 FINAL, 2022-12-15)
+(OCPP). Currently OCPP 1.6 (errata v4), OCPP 2.0.1 (Edition 2 FINAL, 2022-12-15 and Edition 3 errata 2024-11)
 are supported.
 
 You can find the documentation on `rtd`_.


### PR DESCRIPTION
From the readme in the ocpp 2.0.1 edition 3 zipfile https://openchargealliance.org/my-oca/ocpp/:

    For historical reasons not all documents have the same release date. OCPP 2.0.1 Edition 3 is the same as OCPP 2.0.1 Edition 2 including all errata up and until OCPP-2.0.1_edition2_errata_2024-04 (2024-04-30).

    The errata do not affect any schemas of OCPP messages. The errata do contain changes to requirements or even new requirements,
    but only in cases where a requirement contains an obvious error and would not or could not be implemented literally. New
    requirements were only added when they were already implicitly there.

No code changes needed to library then => Updated readme to mention edition 3 support.