### PR TITLE
Relax GetConfigurationResponse value to allow integer also

### DIFF
--- a/ocpp/v16/schemas/GetConfigurationResponse.json
+++ b/ocpp/v16/schemas/GetConfigurationResponse.json
@@ -1,39 +1,36 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "GetConfigurationResponse",
-    "type": "object",
-    "properties": {
-        "configurationKey": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "type": "string",
-                        "maxLength": 50
-                    },
-                    "readonly": {
-                        "type": "boolean"
-                    },
-                    "value": {
-                        "type": "string",
-                        "maxLength": 500
-                    }
-                },
-                "additionalProperties": false,
-                "required": [
-                    "key",
-                    "readonly"
-                ]
-            }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "GetConfigurationResponse",
+  "type": "object",
+  "properties": {
+    "configurationKey": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "maxLength": 50
+          },
+          "readonly": {
+            "type": "boolean"
+          },
+          "value": {
+            "type": ["integer", "string"],
+            "maxLength": 500
+          }
         },
-        "unknownKey": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "maxLength": 50
-            }
-        }
+        "additionalProperties": false,
+        "required": ["key", "readonly"]
+      }
     },
-    "additionalProperties": false
+    "unknownKey": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 50
+      }
+    }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
### Changes included in this PR 

Relaxes the validation schema on the GetConfigurationResponse to allow numerical values in addition to string values.

### Current behavior

Currently, only strings are allowed. Some devices are returning integers, which causes validation failure.

### New behavior

Integers are allowed to be a valid format for the value of the response.

### Impact

Enables use without modification for devices that pass integers directly, rather than encapsulated in strings.

### Checklist

1. [ ] Does your submission pass the existing tests?
2. [ ] Are there new tests that cover these additions/changes? 
3. [ ] Have you linted your code locally before submission?
