### PR TITLE
Updating examples

### DIFF
--- a/examples/v16/central_system.py
+++ b/examples/v16/central_system.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 try:
     import websockets
@@ -26,19 +26,19 @@ class ChargePoint(cp):
     def on_boot_notification(
         self, charge_point_vendor: str, charge_point_model: str, **kwargs
     ):
-        return call_result.BootNotificationPayload(
-            current_time=datetime.utcnow().isoformat(),
+        return call_result.BootNotification(
+            current_time=datetime.now(timezone.utc).isoformat(),
             interval=10,
             status=RegistrationStatus.accepted,
         )
 
 
-async def on_connect(websocket, path):
+async def on_connect(websocket):
     """For every new charge point that connects, create a ChargePoint
     instance and start listening for messages.
     """
     try:
-        requested_protocols = websocket.request_headers["Sec-WebSocket-Protocol"]
+        requested_protocols = websocket.request.headers["Sec-WebSocket-Protocol"]
     except KeyError:
         logging.error("Client hasn't requested any Subprotocol. Closing Connection")
         return await websocket.close()
@@ -56,7 +56,7 @@ async def on_connect(websocket, path):
         )
         return await websocket.close()
 
-    charge_point_id = path.strip("/")
+    charge_point_id = websocket.request.path.strip("/")
     cp = ChargePoint(charge_point_id, websocket)
 
     await cp.start()

--- a/examples/v16/charge_point.py
+++ b/examples/v16/charge_point.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 
 class ChargePoint(cp):
     async def send_boot_notification(self):
-        request = call.BootNotificationPayload(
+        request = call.BootNotification(
             charge_point_model="Optimus", charge_point_vendor="The Mobility House"
         )
 

--- a/examples/v201/charge_point.py
+++ b/examples/v201/charge_point.py
@@ -21,13 +21,13 @@ logging.basicConfig(level=logging.INFO)
 
 class ChargePoint(cp):
     async def send_heartbeat(self, interval):
-        request = call.HeartbeatPayload()
+        request = call.Heartbeat()
         while True:
             await self.call(request)
             await asyncio.sleep(interval)
 
     async def send_boot_notification(self):
-        request = call.BootNotificationPayload(
+        request = call.BootNotification(
             charging_station={"model": "Wallbox XYZ", "vendor_name": "anewone"},
             reason="PowerUp",
         )


### PR DESCRIPTION
### Changes included in this PR 

Updates to the example usage of the library (doc update).

### Current behavior

#708 and #709 describe how the current examples in the documentation fail due to 1) they still use the "Payload" suffix on payload data classes, this is not part of the latest version of this library 2) breaking changes from the WebSockets library, primarily regarding the path parameter passed to the connection handler and where to find the request headers.

### New behavior

This PR updates the example code both for v16 and v201, so that the payload dataclass is correct and is compatible with the latest websockets library.

### Impact

Only changes to documentation. However the documentation currently wouldn't support older versions of websockets library.

### Checklist

1. [x] Does your submission pass the existing tests?
2. [ ] Are there new tests that cover these additions/changes? 
3. [x] Have you linted your code locally before submission?
