### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ code in the `Central System documentation`_.
     from ocpp.routing import on
     from ocpp.v201 import ChargePoint as cp
     from ocpp.v201 import call_result
-    from ocpp.v201.enums import RegistrationStatusType
+    from ocpp.v201.enums import RegistrationStatusEnumType
 
     logging.basicConfig(level=logging.INFO)
 
@@ -87,7 +87,7 @@ code in the `Central System documentation`_.
             return call_result.BootNotificationPayload(
                 current_time=datetime.utcnow().isoformat(),
                 interval=10,
-                status=RegistrationStatusType.accepted
+                status=RegistrationStatusEnumType.accepted
             )
 
 
@@ -141,7 +141,7 @@ Charging Station / Charge point
 
     import asyncio
 
-    from ocpp.v201.enums import RegistrationStatusType
+    from ocpp.v201.enums import RegistrationStatusEnumType
     import logging
     import websockets
 
@@ -163,7 +163,7 @@ Charging Station / Charge point
             )
             response = await self.call(request)
 
-            if response.status == RegistrationStatusType.accepted:
+            if response.status == RegistrationStatusEnumType.accepted:
                 print("Connected to central system.")
 
 


### PR DESCRIPTION
The example code has been updated to use the correct enum name RegistrationStatusEnumType instead of RegistrationStatusType.

### Changes included in this PR 

Bug fix, docs update

### Current behavior
```
Traceback (most recent call last):
  File "/Users/erik/Dev/ocpp-proxy/ocpp_server.py", line 9, in <module>
    from ocpp.v201.enums import RegistrationStatusType
ImportError: cannot import name 'RegistrationStatusType' from 'ocpp.v201.enums' (/Users/erik/.asdf/installs/python/3.11.8/lib/python3.11/site-packages/ocpp/v201/enums.py)
```

### New behavior

```
INFO:websockets.server:server listening on 0.0.0.0:9000
INFO:root:WebSocket Server Started
```