### PR TITLE
Fix build-backend setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,4 @@ profile = "black"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Changes included in this PR 

Fixes the build-backend setting in pyproject.toml to use the correct 'poetry.core.masonry.api'

### Current behavior

Currently `pip install .` fails on Python 3.13.3 with 

> pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'poetry.masonry.api'

### New behavior

`pip install .` works again

### Impact

`pip install .` works again

### Checklist

1. [ ] Does your submission pass the existing tests?
2. [ ] Are there new tests that cover these additions/changes? 
3. [x] Have you linted your code locally before submission?
