### PR TITLE
Feature suggestion: Global Hooks

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,4 +1,11 @@
-from ocpp.routing import after, create_route_map, on
+from ocpp.routing import (
+    after,
+    after_message,
+    before_message,
+    create_route_map,
+    discover_message_hooks,
+    on,
+)
 from ocpp.v16.enums import Action
 
 
@@ -38,4 +45,52 @@ def test_create_route_map():
             "_on_action": cp.meter_values,
             "_skip_schema_validation": False,
         },
+    }
+
+
+def test_discover_message_hooks():
+    """
+    This test validates that message hooks is created correctly and holds all
+    functions decorated with the @before_message and @after_message decorators.
+
+    """
+
+    class ChargePoint:
+        @before_message
+        def before_message_hook(self):
+            pass
+
+        @after_message
+        def after_message_hook(self):
+            pass
+
+        def undecorated(self):
+            pass
+
+    cp = ChargePoint()
+    hooks = discover_message_hooks(cp)
+
+    assert hooks == {
+        "before_message": [cp.before_message_hook],
+        "after_message": [cp.after_message_hook],
+    }
+
+
+def test_discover_message_hooks_empty():
+    """Test that discover_message_hooks works with no hooks."""
+
+    class ChargePoint:
+        @on(Action.heartbeat)
+        def on_heartbeat(self):
+            pass
+
+        def undecorated(self):
+            pass
+
+    cp = ChargePoint()
+    hooks = discover_message_hooks(cp)
+
+    assert hooks == {
+        "before_message": [],
+        "after_message": [],
     }


### PR DESCRIPTION
### Changes included in this PR 

Two new decorators - `before_message` and `after_message` - that can be used to register global hooks. 
Added a `discover_message_hooks` utility function that creates a mapping of hooks for the ChargePoint subclass.
The ChargePoint class stores hook mapping in property `_message_hooks`, it includes a new private method to streamline calling of hooks that handles both synchronous and asynchronous hooks. 
Added hook execution before and after routing the calls.

### Current behavior

If you want to run a function for every call, no matter the type, you currently need to add it to a handler for every type of call (or do some workarounds with overwriting methods). 
I find my self having the same code to save calls on all `@after` handlers.

### New behavior

To add global hooks you can do:
```
...
from ocpp.routing import before_message, after_message


class MyChargePoint(ChargePoint):
    # This will run before call handlers for all types of calls, can also be sync    
    @before_message
    async def some_async_func(self, raw_msg):
        await run_some_code()

    # This will run after call handlers for all types of calls, can also be async
    @after_message
    def some_sync_func(self, raw_msg, parsed_msg):
        run_some_code()
```

### Impact

I believe there is no breaking changes with this implementation.
Global hooks is implemented with the same decorator design as the call handlers.
Question is how useful is it? 
I have one relevant case, saving all calls. But is there other use cases?

Here is further questions to consider with this feature:
- Will it be relevant to call the hooks with parsed data? `unpack` and `camel_to_snake_case` is run after the before hook.
- Does it make sense to enable the hooks to modify call data or returning early error?
- This could also be implemented as hooks to pre- and postprocess sending calls. Will that have any value?

### Checklist

1. [x] Does your submission pass the existing tests?
2. [x] Are there new tests that cover these additions/changes? 
3. [x] Have you linted your code locally before submission?
