### PR TITLE
Makefile update to respect global poetry installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 export PATH := ${HOME}/.local/bin:$(PATH)
 
-IS_POETRY := $(shell pip freeze | grep "poetry==")
+IS_POETRY := $(shell command -v poetry 2>/dev/null)
 
 CURRENT_VERSION := $(shell poetry version -s)
 
@@ -25,7 +25,14 @@ help:
 
 
 .install-poetry:
-	@if [ -z ${IS_POETRY} ]; then pip install poetry; fi
+ifdef IS_POETRY
+	@:
+else
+ifndef VIRTUAL_ENV
+	$(error Please activate a virtual environment or install poetry globally with your preffered tool)
+endif
+	@pip install poetry
+endif
 
 update: .install-poetry
 	poetry update

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifdef IS_POETRY
 	@:
 else
 ifndef VIRTUAL_ENV
-	$(error Please activate a virtual environment or install poetry globally with your preffered tool)
+	$(error Please activate a virtual environment or install poetry globally with your preferred tool)
 endif
 	@pip install poetry
 endif


### PR DESCRIPTION
### Changes included in this PR 

`IS_POETRY` checks for poetry command availability
`.install-poetry` only installs if virtual environment is activated, otherwise prints error message

### Current behavior

The Makefile uses `pip freeze` to check for poetry. 
This requires poetry to either be installed in a global environment or in an activated virtual environment.
Installing will also fail due to PEP 668 unless a virtual environment is active.

### Impact

The change respect multiple modern python tool workflows.
Poetry can be installed with pipx or uv as a globally available tool or locally in a virtual environment.
It also prints a simpler error message if neither is the case and a virtual environment is not activated. 

One possibility is missing though, and that is the ability to run poetry without installing with uvx or pipx.
Does that need to be supported?

### Checklist

1. [x] Does your submission pass the existing tests?
2. [ ] Are there new tests that cover these additions/changes? 
3. [ ] Have you linted your code locally before submission?
