### PR TITLE
Update minimum python version (3.9) in pyproject.toml and docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,7 +15,7 @@ Or clone the project and install it manually using:
 
 **Dependencies**
 
-- Python 3.7 or higher
+- Python 3.9 or higher
 - The project also requires a websocket library. We recommend using `websockets`_:
 
     .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,10 @@ classifiers = [
 	'Programming Language :: Python :: 3.11',
 	'Programming Language :: Python :: 3.10',
 	'Programming Language :: Python :: 3.9',
-	'Programming Language :: Python :: 3.8',
 ]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.9"
 jsonschema = "^4.23.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### Changes included in this PR 

* Update minimum python version (3.9) in pyproject.toml and docs

### Current behavior

* The docs state that a minimum of python 3.7 is supported
* The classifiers in `pyproject.toml` state that a minimum of python 3.8 is supported
* The `tool.poetry.dependencies` requires python 3.11
* This results in the latest release (2.1.0) on pypi not being listed in `pip index versions ocpp` and not being available to install (by default) ob Ubuntu 22.04, which ships python 3.10
* 

### New behavior

* A consistent minimum python version of 3.9 is used (lower than that did not work without further changes)

### Impact

* Installing is possible again on older python versions

### Checklist

1. [ ] Does your submission pass the existing tests?
2. [ ] Are there new tests that cover these additions/changes? 
3. [ ] Have you linted your code locally before submission?
