### PR TITLE
Added Hz as a valid enum

### DIFF
--- a/ocpp/v16/schemas/MeterValues.json
+++ b/ocpp/v16/schemas/MeterValues.json
@@ -126,7 +126,8 @@
                                         "Celsius",
                                         "Fahrenheit",
                                         "Percent",
-                                        "Hertz"
+                                        "Hertz",
+                                        "Hz"
                                     ]
                                 }
                             },


### PR DESCRIPTION
### Added Hz as valid units

I know that Hz is not a standard unit, but it some chargers spit measurements with those units, and since the library raises an error I assumed that this could be added, in the same way that Hertz was added to the schema, since it is not part of the standard.

Could we merge this?
Best regards.
