### PR TITLE
fix: deduplicate 201 types

### DIFF
--- a/ocpp/v201/datatypes.py
+++ b/ocpp/v201/datatypes.py
@@ -359,27 +359,6 @@ class CompositeScheduleType:
 
 
 @dataclass
-class CostType:
-    """
-    CostType is used by: ConsumptionCostType
-    """
-
-    cost_kind: enums.CostKindEnumType
-    amount: int
-    amount_multiplier: Optional[int] = None
-
-
-@dataclass
-class ConsumptionCostType:
-    """
-    ConsumptionCostType is used by: SalesTariffEntryType
-    """
-
-    start_value: float
-    cost: List[CostType]
-
-
-@dataclass
 class EventDataType:
     """
     Class to report an event notification for a component-variable.
@@ -733,19 +712,6 @@ class ReportDataType:
     variable: VariableType
     variable_attribute: List[VariableAttributeType]
     variable_characteristics: Optional[VariableCharacteristicsType] = None
-
-
-@dataclass
-class SalesTariffType:
-    """
-    This dataType is based on dataTypes from ISO 15118-2.
-    SalesTariffType is used by: ChargingScheduleType
-    """
-
-    id: int
-    sales_tariff_entry: List[SalesTariffEntryType]
-    sales_tariff_description: Optional[str] = None
-    num_e_price_levels: Optional[int] = None
 
 
 @dataclass


### PR DESCRIPTION
### Changes included in this PR 

`CostType`, `ConsumptionCostType`, and `SalesTariffType` were duplicated in the ocpp/v201/datatypes - this just removes the second duplicate definitions

### Current behavior

None

### New behavior

None

### Impact

None

### Checklist

1. [x] Does your submission pass the existing tests?
2. [x] Are there new tests that cover these additions/changes? 
3. [x] Have you linted your code locally before submission?
