### PR TITLE
ci: run the test matrix on the actual matrix interpreter, split lint from tests

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.13'
 
     - name: Gets the tag version
       id: context
@@ -22,6 +22,10 @@ jobs:
 
     - name: Setup the Python Environment by installing Poetry
       uses: ./.github/actions/setup-python-build-env
+
+    - name: Bind Poetry to the selected interpreter
+      shell: bash
+      run: poetry env use "$(which python)"
 
     - name: Code Quality Check
       shell: bash

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,14 +6,35 @@ on:
       - master
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Setup the Python Environment by installing Poetry
+        uses: ./.github/actions/setup-python-build-env
+
+      - name: Bind Poetry to the selected interpreter
+        shell: bash
+        run: poetry env use "$(which python)"
+
+      - name: Install dependencies
+        shell: bash
+        run: make install
+
+      - name: Lint
+        shell: bash
+        run: make lint
+
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         version:
-        - "3.8"
-        - "3.9"
-        - "3.10"
         - "3.11"
         - "3.12"
         - "3.13"
@@ -27,7 +48,19 @@ jobs:
       - name: Setup the Python Environment by installing Poetry
         uses: ./.github/actions/setup-python-build-env
 
-      - name: Code Quality Check
+      - name: Bind Poetry to Python ${{ matrix.version }}
+        shell: bash
+        run: poetry env use "$(which python)"
+
+      - name: Install dependencies
+        shell: bash
+        run: make install
+
+      - name: Verify tests run on Python ${{ matrix.version }}
         shell: bash
         run: |
-          make install && make tests
+          poetry run python -c 'import sys; expected = tuple(int(p) for p in "${{ matrix.version }}".split(".")); assert sys.version_info[:2] == expected, f"expected Python {expected}, got {sys.version}"; print(sys.version)'
+
+      - name: Run tests
+        shell: bash
+        run: make unit-tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help .check-pypi-envs .install-poetry update install docs tests build deploy
+.PHONY: help .check-pypi-envs .install-poetry update install docs lint unit-tests tests build deploy
 
 .DEFAULT_GOAL := help
 
@@ -18,6 +18,8 @@ help:
 	@echo "  release version=<sem. version>   bumps the project version to <sem. version>, using poetry;"
 	@echo "                                   Updates also docs/source/conf.py version;"
 	@echo "                                   If no version is provided, poetry outputs the current project version"
+	@echo "  lint                             run the linting checks (black, isort, flake8)"
+	@echo "  unit-tests                       run the test suite"
 	@echo "  tests                            run all the tests and linting"
 	@echo "  update                           updates the dependencies in poetry.lock"
 	@echo ""
@@ -39,11 +41,15 @@ docs: .install-poetry
 format: .install-poetry
 	poetry run isort ocpp tests && poetry run black ocpp tests
 
-tests: .install-poetry
+lint: .install-poetry
 	poetry run black --check --diff ocpp tests
 	poetry run isort --check-only ocpp tests
 	poetry run flake8 ocpp tests
+
+unit-tests: .install-poetry
 	poetry run py.test -vvv --cov=ocpp --cov-report=term-missing tests/
+
+tests: lint unit-tests
 
 build: .install-poetry
 	poetry build


### PR DESCRIPTION
### The problem

The CI matrix has not been testing the Python versions it claims to. The `setup-python-build-env` composite action installs Poetry via `pipx`, and Poetry then builds the project virtualenv from **pipx's own interpreter**, not the one selected by `actions/setup-python`. Every matrix job — including the "3.8" one — has actually been running against the runner's default Python (3.12). This was spotted by @hikinggrass in the #740 discussion, with a job run demonstrating it: https://github.com/mobilityhouse/ocpp/actions/runs/16022303628/job/45201948389

Practical consequence: the matrix has never genuinely verified support below 3.11, which is how the classifier/`requires_python` drift shipped in 2.1.0 without any red CI.

### The fix

**`.github/workflows/pull-request.yml`**
- After `setup-python`, run `poetry env use "$(which python)"` so the project venv is built from the matrix interpreter
- Add a **verification step** that asserts `sys.version_info` inside the venv matches `matrix.version` — the matrix can no longer silently lie; if the binding ever regresses, the job fails loudly
- Trim the matrix to `3.11 / 3.12 / 3.13` — the range `pyproject.toml` actually declares (`^3.11`). The 3.8–3.10 jobs are removed rather than fixed because, once honest, they *cannot* pass today (`poetry install` refuses interpreters outside the project's range). They return in the follow-up to #740 when the floor is genuinely lowered.
- Split lint out of the matrix: a single `lint` job on 3.13 runs black/isort/flake8; matrix jobs run only the test suite. Lint results don't vary by interpreter, and this also unblocks the #740 follow-up where lint tools (black 26 ≥3.10, sphinx ≥3.11) won't be installed on older-Python jobs.

**`Makefile`**
- `tests` split into `lint` and `unit-tests` targets; `make tests` runs both, so local usage is unchanged

**`.github/workflows/publish-to-pypi.yml`**
- Pinned interpreter bumped 3.10 → 3.13 — it was *below* the package's own `^3.11` floor and only worked via the same pipx accident — and Poetry is bound with `poetry env use` the same way

### Verification

- `make tests` (lint + 181 tests) passes locally through the new targets
- The interpreter assertion one-liner validated standalone
- This PR's own CI run exercises the new workflow

### Sequencing

This is deliberately infrastructure-only — no `pyproject.toml` changes. It merges first so the matrix is trustworthy *before* the Python-floor change: the follow-up to #740 (lower floor to `^3.9`, lockfile regen, dev-dependency markers) will extend the matrix to 3.9/3.10, and its green checks will then actually mean the suite runs on those interpreters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)