### PR TITLE
Gate the StrEnum fallback on sys.version_info instead of try/except

### DIFF
--- a/ocpp/v16/enums.py
+++ b/ocpp/v16/enums.py
@@ -1,11 +1,13 @@
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     # breaking change introduced in python 3.11
     from enum import StrEnum
-except ImportError:  # pragma: no cover
-    from enum import Enum  # pragma: no cover
+else:  # pragma: no cover
+    from enum import Enum
 
-    class StrEnum(str, Enum):  # pragma: no cover
-        pass  # pragma: no cover
+    class StrEnum(str, Enum):
+        pass
 
 
 class Action(StrEnum):

--- a/ocpp/v201/enums.py
+++ b/ocpp/v201/enums.py
@@ -1,11 +1,13 @@
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     # breaking change introduced in python 3.11
     from enum import StrEnum
-except ImportError:  # pragma: no cover
-    from enum import Enum  # pragma: no cover
+else:  # pragma: no cover
+    from enum import Enum
 
-    class StrEnum(str, Enum):  # pragma: no cover
-        pass  # pragma: no cover
+    class StrEnum(str, Enum):
+        pass
 
 
 class Action(StrEnum):

--- a/ocpp/v21/enums.py
+++ b/ocpp/v21/enums.py
@@ -1,11 +1,13 @@
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     # breaking change introduced in python 3.11
     from enum import StrEnum
-except ImportError:  # pragma: no cover
-    from enum import Enum  # pragma: no cover
+else:  # pragma: no cover
+    from enum import Enum
 
-    class StrEnum(str, Enum):  # pragma: no cover
-        pass  # pragma: no cover
+    class StrEnum(str, Enum):
+        pass
 
 
 class Action(StrEnum):


### PR DESCRIPTION
### Changes included in this PR

Compat chore: replace the `try/except ImportError` StrEnum fallback with a `sys.version_info >= (3, 11)` gate in the three `enums.py` modules (v16, v201, v21).

### Current behavior

Static type checkers can't tell which branch of a `try/except ImportError` wins, so the `StrEnum` base — and with it the type of every enum member — is ambiguous to them. Checking a downstream codebase with [ty](https://github.com/astral-sh/ty) reports `invalid-argument-type` every time an enum member is passed to a parameter annotated with its own enum type (e.g. `RegistrationStatus.accepted` against a `status: RegistrationStatus` field).

<details>
<summary>Minimal repro (ty 0.0.61)</summary>

```python
try:
    from enum import StrEnum
except ImportError:
    from enum import Enum

    class StrEnum(str, Enum):
        pass


class Color(StrEnum):
    red = "RED"


def f(c: Color) -> None: ...


f(Color.red)  # error[invalid-argument-type]
```

The same snippet with `if sys.version_info >= (3, 11):` passes cleanly.

</details>

### New behavior

None at runtime: `enum.StrEnum` is still used on 3.11+, and the fallback still covers 3.8–3.10. `sys.version_info` gates are the idiom type checkers special-case and prune (it's what typeshed uses throughout), so enum members type correctly again. On a downstream CSMS project, ty went from 43 to 24 diagnostics with this patch — all 19 removed were these false positives.

### Impact

No breaking change; the import logic is identical at runtime. The `# pragma: no cover` moves onto the `else:` clause (`ocpp/v16/enums.py` still reports 100% coverage locally), and the CI matrix already exercises both branches (3.8–3.10 take the fallback, 3.11–3.13 the stdlib import).

### Checklist

1. [x] Does your submission pass the existing tests? — 182 passed, via `poetry install` + the `make tests` commands
2. [ ] Are there new tests that cover these additions/changes? — no behavior change to cover; both branches are already exercised by the 3.8–3.13 CI matrix
3. [x] Have you linted your code locally before submission? — black, isort and flake8 all clean
